### PR TITLE
Fix correctness and security issues from code review

### DIFF
--- a/3rd/auth/pkg/authfx/firebase_middleware.go
+++ b/3rd/auth/pkg/authfx/firebase_middleware.go
@@ -2,6 +2,7 @@ package authfx
 
 import (
 	"context"
+	"sync"
 
 	firebase "firebase.google.com/go/v4"
 	auth2 "firebase.google.com/go/v4/auth"
@@ -20,6 +21,7 @@ import (
 // FirebaseAuthor is auth for grpc middleware
 type FirebaseAuthor struct {
 	client        *auth2.Client
+	mu            sync.RWMutex
 	unAuthMethods map[string]struct{}
 }
 
@@ -30,7 +32,10 @@ type FirebaseAuthor struct {
 // if you need to check the token has not been revoked please use VerifyIDTokenAndCheckRevoked to replace VerifyIDToken.
 func (d *FirebaseAuthor) Auth(ctx context.Context) (context.Context, error) {
 	method, _ := grpc.Method(ctx)
-	if _, ok := d.unAuthMethods[method]; ok {
+	d.mu.RLock()
+	_, skip := d.unAuthMethods[method]
+	d.mu.RUnlock()
+	if skip {
 		return context.WithValue(ctx, utility.WithOutTag, true), nil
 	} else if token, err := auth.AuthFromMD(ctx, string(utility.TokenContextKey)); err != nil {
 		return ctx, err
@@ -44,6 +49,8 @@ func (d *FirebaseAuthor) Auth(ctx context.Context) (context.Context, error) {
 
 // AddUnAuthMethod add unauth method
 func (d *FirebaseAuthor) AddUnAuthMethod(method string) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
 	if d.unAuthMethods == nil {
 		d.unAuthMethods = make(map[string]struct{})
 	}

--- a/3rd/auth/pkg/authfx/supabase_middleware.go
+++ b/3rd/auth/pkg/authfx/supabase_middleware.go
@@ -2,6 +2,7 @@ package authfx
 
 import (
 	"context"
+	"sync"
 
 	"github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/auth"
 	"github.com/supabase-community/supabase-go"
@@ -19,13 +20,17 @@ import (
 // SupabaseAuthor is auth for grpc middleware
 type SupabaseAuthor struct {
 	client        *supabase.Client
+	mu            sync.RWMutex
 	unAuthMethods map[string]struct{}
 }
 
 // Auth will auth every grpc request with supabase
 func (d *SupabaseAuthor) Auth(ctx context.Context) (context.Context, error) {
 	method, _ := grpc.Method(ctx)
-	if _, ok := d.unAuthMethods[method]; ok {
+	d.mu.RLock()
+	_, skip := d.unAuthMethods[method]
+	d.mu.RUnlock()
+	if skip {
 		return context.WithValue(ctx, utility.WithOutTag, true), nil
 	} else if token, err := auth.AuthFromMD(ctx, string(utility.TokenContextKey)); err != nil {
 		return ctx, err
@@ -39,6 +44,8 @@ func (d *SupabaseAuthor) Auth(ctx context.Context) (context.Context, error) {
 
 // AddUnAuthMethod add unauth method
 func (d *SupabaseAuthor) AddUnAuthMethod(method string) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
 	if d.unAuthMethods == nil {
 		d.unAuthMethods = make(map[string]struct{})
 	}

--- a/mq/internal/local/message_queue_test.go
+++ b/mq/internal/local/message_queue_test.go
@@ -1,0 +1,47 @@
+package local
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"go.uber.org/zap"
+
+	"github.com/gstones/moke-kit/mq/common"
+	"github.com/gstones/moke-kit/mq/miface"
+)
+
+func TestLocalSubscribeReturnsValidSubscription(t *testing.T) {
+	mq := NewMessageQueue(zap.NewNop(), 16, false, false)
+	var got atomic.Int32
+	sub, err := mq.Subscribe(context.Background(), "topic-a", func(msg miface.Message, err error) common.ConsumptionCode {
+		got.Add(1)
+		return common.ConsumeAck
+	})
+	if err != nil {
+		t.Fatalf("Subscribe error: %v", err)
+	}
+	if sub == nil || !sub.IsValid() {
+		t.Fatal("expected non-nil valid subscription")
+	}
+
+	if err := mq.Publish("topic-a", miface.WithBytes([]byte("hello"))); err != nil {
+		t.Fatalf("Publish error: %v", err)
+	}
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) && got.Load() == 0 {
+		time.Sleep(10 * time.Millisecond)
+	}
+	if got.Load() == 0 {
+		t.Fatal("expected message to be consumed")
+	}
+
+	if err := sub.Unsubscribe(); err != nil {
+		t.Fatalf("Unsubscribe error: %v", err)
+	}
+	if sub.IsValid() {
+		t.Fatal("expected subscription invalid after unsubscribe")
+	}
+}

--- a/mq/internal/local/subscription.go
+++ b/mq/internal/local/subscription.go
@@ -7,30 +7,28 @@ import (
 
 	"github.com/gstones/moke-kit/mq/common"
 	message2 "github.com/gstones/moke-kit/mq/internal/message"
+	"github.com/gstones/moke-kit/mq/internal/subscription"
 	"github.com/gstones/moke-kit/mq/miface"
 )
-
-type Subscription struct {
-	topic      string
-	handler    miface.SubResponseHandler
-	subscriber message.Subscriber
-}
 
 func CreateSubscription(
 	ctx context.Context,
 	topic string,
 	handler miface.SubResponseHandler,
 	subscriber message.Subscriber,
-) (*Subscription, error) {
-	sub := &Subscription{topic: topic, handler: handler, subscriber: subscriber}
-	msgIn, err := subscriber.Subscribe(ctx, topic)
+) (miface.Subscription, error) {
+	subCtx, cancel := context.WithCancel(ctx)
+	msgIn, err := subscriber.Subscribe(subCtx, topic)
 	if err != nil {
+		cancel()
 		return nil, err
 	}
+	sub := subscription.NewCancelSubscription(cancel)
 	go func() {
+		defer sub.Unsubscribe()
 		for msg := range msgIn {
 			m := message2.Msg2Message(topic, msg)
-			if code := sub.handler(m, nil); code == common.ConsumeNackTransientFailure {
+			if code := handler(m, nil); code == common.ConsumeNackTransientFailure {
 				msg.Nack()
 			} else {
 				msg.Ack()
@@ -38,16 +36,4 @@ func CreateSubscription(
 		}
 	}()
 	return sub, nil
-}
-
-func (s *Subscription) IsValid() bool {
-	return s.subscriber != nil
-}
-
-func (s *Subscription) Unsubscribe() error {
-	if err := s.subscriber.Close(); err != nil {
-		return err
-	}
-	s.subscriber = nil
-	return nil
 }

--- a/mq/internal/nats/message_queue.go
+++ b/mq/internal/nats/message_queue.go
@@ -15,6 +15,7 @@ import (
 	"github.com/gstones/moke-kit/mq/internal/logger"
 	message2 "github.com/gstones/moke-kit/mq/internal/message"
 	"github.com/gstones/moke-kit/mq/internal/qerrors"
+	"github.com/gstones/moke-kit/mq/internal/subscription"
 	"github.com/gstones/moke-kit/mq/miface"
 )
 
@@ -86,20 +87,23 @@ func (m *MessageQueue) Subscribe(
 	ctx context.Context,
 	topic string,
 	handler miface.SubResponseHandler,
-	sOpts ...miface.SubOption,
+	_ ...miface.SubOption,
 ) (miface.Subscription, error) {
 	if topic == "" {
 		return nil, qerrors.ErrEmptyTopic
-	} else {
-		topic = common.NamespaceTopic(topic)
 	}
+	topic = common.NamespaceTopic(topic)
 
-	msgChan, err := m.subscribe.Subscribe(ctx, topic)
+	subCtx, cancel := context.WithCancel(ctx)
+	msgChan, err := m.subscribe.Subscribe(subCtx, topic)
 	if err != nil {
+		cancel()
 		return nil, err
 	}
 
+	sub := subscription.NewCancelSubscription(cancel)
 	go func() {
+		defer sub.Unsubscribe()
 		for msg := range msgChan {
 			ms := message2.Msg2Message(topic, msg)
 			if code := handler(ms, nil); code == common.ConsumeNackTransientFailure {
@@ -109,15 +113,14 @@ func (m *MessageQueue) Subscribe(
 			}
 		}
 	}()
-	return nil, nil
+	return sub, nil
 }
 
 func (m *MessageQueue) Publish(topic string, pOpts ...miface.PubOption) error {
 	if topic == "" {
 		return qerrors.ErrEmptyTopic
-	} else {
-		topic = common.NamespaceTopic(topic)
 	}
+	topic = common.NamespaceTopic(topic)
 
 	if options, err := miface.NewPubOptions(pOpts...); err != nil {
 		return err

--- a/mq/internal/subscription/subscription.go
+++ b/mq/internal/subscription/subscription.go
@@ -1,0 +1,38 @@
+package subscription
+
+import (
+	"sync/atomic"
+)
+
+// CancelSubscription implements miface.Subscription by cancelling a per-subscribe
+// context instead of closing a shared Watermill subscriber.
+type CancelSubscription struct {
+	cancel  func()
+	valid   atomic.Bool
+	closed  atomic.Bool
+}
+
+// NewCancelSubscription creates a valid subscription that cancels via cancel.
+func NewCancelSubscription(cancel func()) *CancelSubscription {
+	s := &CancelSubscription{cancel: cancel}
+	s.valid.Store(true)
+	return s
+}
+
+func (s *CancelSubscription) IsValid() bool {
+	return s != nil && s.valid.Load()
+}
+
+func (s *CancelSubscription) Unsubscribe() error {
+	if s == nil {
+		return nil
+	}
+	if !s.closed.CompareAndSwap(false, true) {
+		return nil
+	}
+	s.valid.Store(false)
+	if s.cancel != nil {
+		s.cancel()
+	}
+	return nil
+}

--- a/mq/internal/subscription/subscription.go
+++ b/mq/internal/subscription/subscription.go
@@ -7,9 +7,9 @@ import (
 // CancelSubscription implements miface.Subscription by cancelling a per-subscribe
 // context instead of closing a shared Watermill subscriber.
 type CancelSubscription struct {
-	cancel  func()
-	valid   atomic.Bool
-	closed  atomic.Bool
+	cancel func()
+	valid  atomic.Bool
+	closed atomic.Bool
 }
 
 // NewCancelSubscription creates a valid subscription that cancels via cancel.
@@ -19,10 +19,12 @@ func NewCancelSubscription(cancel func()) *CancelSubscription {
 	return s
 }
 
+// IsValid reports whether the subscription is still active.
 func (s *CancelSubscription) IsValid() bool {
 	return s != nil && s.valid.Load()
 }
 
+// Unsubscribe cancels the subscription. It is safe to call more than once.
 func (s *CancelSubscription) Unsubscribe() error {
 	if s == nil {
 		return nil

--- a/mq/internal/subscription/subscription_test.go
+++ b/mq/internal/subscription/subscription_test.go
@@ -1,0 +1,24 @@
+package subscription
+
+import "testing"
+
+func TestCancelSubscription(t *testing.T) {
+	called := false
+	sub := NewCancelSubscription(func() { called = true })
+	if !sub.IsValid() {
+		t.Fatal("expected valid subscription")
+	}
+	if err := sub.Unsubscribe(); err != nil {
+		t.Fatalf("Unsubscribe error: %v", err)
+	}
+	if !called {
+		t.Fatal("expected cancel to be called")
+	}
+	if sub.IsValid() {
+		t.Fatal("expected invalid after unsubscribe")
+	}
+	// idempotent
+	if err := sub.Unsubscribe(); err != nil {
+		t.Fatalf("second Unsubscribe error: %v", err)
+	}
+}

--- a/mq/pkg/mfx/nats_mq.go
+++ b/mq/pkg/mfx/nats_mq.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/gstones/moke-kit/mq/internal/nats"
 	"github.com/gstones/moke-kit/mq/miface"
+	"github.com/gstones/moke-kit/utility"
 )
 
 type NatsResult struct {
@@ -18,7 +19,7 @@ func (k *NatsResult) init(logger *zap.Logger, s SettingsParams) error {
 	if err != nil {
 		logger.Error("Nats message queue connect failure:",
 			zap.Error(err),
-			zap.String("address", s.NatsUrl))
+			zap.String("address", utility.RedactURL(s.NatsUrl)))
 		return err
 	}
 	k.NatsMQ = mq

--- a/orm/nosql/cache/redis_cache.go
+++ b/orm/nosql/cache/redis_cache.go
@@ -31,6 +31,9 @@ func CreateRedisCache(logger *zap.Logger, client *redis.Client) *RedisCache {
 
 // GetCache gets cache
 func (c *RedisCache) GetCache(ctx context.Context, key key.Key, doc any) bool {
+	if c == nil || c.Client == nil {
+		return false
+	}
 	if res := c.Get(ctx, key.String()); res.Err() != nil {
 		return false
 	} else if data, err := res.Bytes(); err != nil {
@@ -43,6 +46,9 @@ func (c *RedisCache) GetCache(ctx context.Context, key key.Key, doc any) bool {
 
 // SetCache sets cache
 func (c *RedisCache) SetCache(ctx context.Context, key key.Key, doc any, expire time.Duration) {
+	if c == nil || c.Client == nil {
+		return
+	}
 	if data, err := json.Marshal(doc); err != nil {
 		return
 	} else if res := c.Set(ctx, key.String(), data, expire); res.Err() != nil {
@@ -52,6 +58,9 @@ func (c *RedisCache) SetCache(ctx context.Context, key key.Key, doc any, expire 
 
 // DeleteCache deletes cache
 func (c *RedisCache) DeleteCache(ctx context.Context, key key.Key) {
+	if c == nil || c.Client == nil {
+		return
+	}
 	if res := c.Del(ctx, key.String()); res.Err() != nil {
 		return
 	}

--- a/orm/nosql/cache/redis_cache_test.go
+++ b/orm/nosql/cache/redis_cache_test.go
@@ -1,0 +1,25 @@
+package cache
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"go.uber.org/zap"
+
+	"github.com/gstones/moke-kit/orm/nosql/key"
+)
+
+func TestRedisCacheNilClientNoPanic(t *testing.T) {
+	c := CreateRedisCache(zap.NewNop(), nil)
+	k, err := key.NewKeyFromParts("a", "b")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var dst map[string]string
+	if c.GetCache(context.Background(), k, &dst) {
+		t.Fatal("expected cache miss")
+	}
+	c.SetCache(context.Background(), k, map[string]string{"x": "y"}, time.Minute)
+	c.DeleteCache(context.Background(), k)
+}

--- a/orm/nosql/mock/internal/collection.go
+++ b/orm/nosql/mock/internal/collection.go
@@ -3,97 +3,143 @@ package internal
 import (
 	"context"
 	"encoding/json"
+	"sync"
 
 	"github.com/stretchr/testify/mock"
 
+	"github.com/gstones/moke-kit/orm/nerrors"
 	"github.com/gstones/moke-kit/orm/nosql/key"
 	"github.com/gstones/moke-kit/orm/nosql/noptions"
 )
 
-type MockCollection struct {
-	mock.Mock
+type docEntry struct {
 	data    []byte
 	version noptions.Version
 }
 
+type MockCollection struct {
+	mock.Mock
+	mu   sync.Mutex
+	docs map[string]*docEntry
+}
+
 func NewMockCollection(name string) *MockCollection {
 	mc := &MockCollection{
-		version: 0,
+		docs: make(map[string]*docEntry),
 	}
 	mc.On("GetName").Return(name)
-	mc.On("Set", mock.Anything, mock.Anything, mock.Anything).Return(func(ctx context.Context, key key.Key, opts ...noptions.Option) noptions.Version {
-		mc.version++
-		return mc.version
-	}, nil)
-	mc.On("Get", mock.Anything, mock.Anything, mock.Anything).Return(func(ctx context.Context, key key.Key, opts ...noptions.Option) noptions.Version {
-		if mc.version == 0 {
-			mc.version = 1 // 确保至少返回版本1
-		}
-		return mc.version
-	}, nil)
-	mc.On("Delete", mock.Anything, mock.Anything).Return(nil)
-	mc.On("Incr", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(int64(1), nil)
+	mc.On("Set", mock.Anything, mock.Anything, mock.Anything).Maybe()
+	mc.On("Get", mock.Anything, mock.Anything, mock.Anything).Maybe()
+	mc.On("Delete", mock.Anything, mock.Anything).Maybe()
+	mc.On("Incr", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Maybe()
 	return mc
 }
 
 func (m *MockCollection) GetName() string {
 	ret := m.Called()
-	r0 := ret.Get(0).(string)
-	return r0
+	return ret.Get(0).(string)
 }
 
-func (m *MockCollection) Set(ctx context.Context, key key.Key, opts ...noptions.Option) (noptions.Version, error) {
+func (m *MockCollection) Set(ctx context.Context, k key.Key, opts ...noptions.Option) (noptions.Version, error) {
+	m.Called(ctx, k, opts)
 	options, err := noptions.NewOptions(opts...)
 	if err != nil {
 		return noptions.NoVersion, err
 	}
-	if options.Source != nil {
-		jsonData, err := json.Marshal(options.Source)
-		if err != nil {
-			return noptions.NoVersion, err
-		}
-		m.data = jsonData
+	if options.Source == nil {
+		return noptions.NoVersion, nerrors.ErrSourceIsNil
 	}
-	// 直接增加版本号
-	m.version++
-	
-	ret := m.Called(ctx, key, opts)
-	return m.version, ret.Error(1)
+	jsonData, err := json.Marshal(options.Source)
+	if err != nil {
+		return noptions.NoVersion, err
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	id := k.String()
+	entry, exists := m.docs[id]
+
+	if !options.AnyVersion && options.Version == noptions.NoVersion {
+		if exists {
+			return noptions.NoVersion, nerrors.ErrVersionNotMatch
+		}
+		m.docs[id] = &docEntry{data: jsonData, version: 1}
+		return 1, nil
+	}
+	if !options.AnyVersion {
+		if !exists || entry.version != options.Version {
+			return noptions.NoVersion, nerrors.ErrVersionNotMatch
+		}
+		entry.data = jsonData
+		entry.version++
+		return entry.version, nil
+	}
+	if !exists {
+		m.docs[id] = &docEntry{data: jsonData, version: 1}
+		return 1, nil
+	}
+	entry.data = jsonData
+	entry.version++
+	return entry.version, nil
 }
 
 func (m *MockCollection) Get(
 	ctx context.Context,
-	key key.Key,
+	k key.Key,
 	opts ...noptions.Option,
 ) (noptions.Version, error) {
+	m.Called(ctx, k, opts)
 	options, err := noptions.NewOptions(opts...)
 	if err != nil {
 		return noptions.NoVersion, err
 	}
 
-	if options.Destination != nil && m.data != nil {
-		json.Unmarshal(m.data, options.Destination)
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	entry, exists := m.docs[k.String()]
+	if !exists {
+		return noptions.NoVersion, nerrors.ErrNotFound
 	}
-
-	ret := m.Called(ctx, key, opts)
-	
-	// 确保返回有效的版本号
-	if m.version == 0 {
-		m.version = 1
+	if options.Version != noptions.NoVersion && entry.version != options.Version {
+		return noptions.NoVersion, nerrors.ErrNotFound
 	}
-	
-	return m.version, ret.Error(1)
+	if options.Destination != nil && entry.data != nil {
+		if err := json.Unmarshal(entry.data, options.Destination); err != nil {
+			return noptions.NoVersion, err
+		}
+	}
+	return entry.version, nil
 }
 
-func (m *MockCollection) Delete(ctx context.Context, key key.Key) error {
-	ret := m.Called(ctx, key)
-	r0 := ret.Error(0)
-	return r0
+func (m *MockCollection) Delete(ctx context.Context, k key.Key) error {
+	m.Called(ctx, k)
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if _, exists := m.docs[k.String()]; !exists {
+		return nerrors.ErrNotFound
+	}
+	delete(m.docs, k.String())
+	return nil
 }
 
-func (m *MockCollection) Incr(ctx context.Context, key key.Key, field string, amount int32) (int64, error) {
-	ret := m.Called(ctx, key, field, amount)
-	r0 := ret.Get(0).(int64)
-	r1 := ret.Error(1)
-	return r0, r1
+func (m *MockCollection) Incr(ctx context.Context, k key.Key, field string, amount int32) (int64, error) {
+	m.Called(ctx, k, field, amount)
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	id := k.String()
+	entry, exists := m.docs[id]
+	var values map[string]int64
+	if !exists {
+		values = map[string]int64{field: int64(amount)}
+		data, _ := json.Marshal(values)
+		m.docs[id] = &docEntry{data: data, version: 1}
+		return int64(amount), nil
+	}
+	values = map[string]int64{}
+	_ = json.Unmarshal(entry.data, &values)
+	values[field] += int64(amount)
+	data, _ := json.Marshal(values)
+	entry.data = data
+	return values[field], nil
 }

--- a/orm/nosql/mock/internal/collection.go
+++ b/orm/nosql/mock/internal/collection.go
@@ -17,12 +17,14 @@ type docEntry struct {
 	version noptions.Version
 }
 
+// MockCollection is an in-memory ICollection used for tests.
 type MockCollection struct {
 	mock.Mock
 	mu   sync.Mutex
 	docs map[string]*docEntry
 }
 
+// NewMockCollection creates a MockCollection with the given name.
 func NewMockCollection(name string) *MockCollection {
 	mc := &MockCollection{
 		docs: make(map[string]*docEntry),
@@ -35,11 +37,13 @@ func NewMockCollection(name string) *MockCollection {
 	return mc
 }
 
+// GetName returns the collection name.
 func (m *MockCollection) GetName() string {
 	ret := m.Called()
 	return ret.Get(0).(string)
 }
 
+// Set stores a document using create/CAS/any-version semantics.
 func (m *MockCollection) Set(ctx context.Context, k key.Key, opts ...noptions.Option) (noptions.Version, error) {
 	m.Called(ctx, k, opts)
 	options, err := noptions.NewOptions(opts...)
@@ -83,6 +87,7 @@ func (m *MockCollection) Set(ctx context.Context, k key.Key, opts ...noptions.Op
 	return entry.version, nil
 }
 
+// Get loads a document into the destination option and returns its version.
 func (m *MockCollection) Get(
 	ctx context.Context,
 	k key.Key,
@@ -111,6 +116,7 @@ func (m *MockCollection) Get(
 	return entry.version, nil
 }
 
+// Delete removes a document. It returns ErrNotFound if the key does not exist.
 func (m *MockCollection) Delete(ctx context.Context, k key.Key) error {
 	m.Called(ctx, k)
 	m.mu.Lock()
@@ -122,6 +128,7 @@ func (m *MockCollection) Delete(ctx context.Context, k key.Key) error {
 	return nil
 }
 
+// Incr increments a numeric field and returns the new value.
 func (m *MockCollection) Incr(ctx context.Context, k key.Key, field string, amount int32) (int64, error) {
 	m.Called(ctx, k, field, amount)
 	m.mu.Lock()

--- a/orm/nosql/mongo/internal/driver.go
+++ b/orm/nosql/mongo/internal/driver.go
@@ -23,9 +23,10 @@ func (dd *DatabaseDriver) GetName() string {
 	return dd.database.Name()
 }
 
-// Set with a key and options
-// If the version is not noVersion, then the version must match the version in the database,
-// Or it will return error `ErrVersionNotMatch`
+// Set with a key and options.
+// - No version and not AnyVersion: create only (fails if document exists).
+// - WithVersion: CAS update (fails if version mismatches).
+// - WithAnyVersion: overwrite/create regardless of current version.
 func (dd *DatabaseDriver) Set(ctx context.Context, key key.Key, opts ...noptions.Option) (noptions.Version, error) {
 	o, err := noptions.NewOptions(opts...)
 	if err != nil {
@@ -36,30 +37,53 @@ func (dd *DatabaseDriver) Set(ctx context.Context, key key.Key, opts ...noptions
 	}
 
 	coll := dd.database.Collection(key.Prefix())
-	filter := bson.M{"_id": key.String()}
-	opt := options.Update()
 
-	if o.Version != noptions.NoVersion {
+	// Create-only: document must not already exist.
+	if !o.AnyVersion && o.Version == noptions.NoVersion {
+		doc := bson.M{
+			"_id":     key.String(),
+			"data":    o.Source,
+			"version": int64(1),
+		}
+		if _, err := coll.InsertOne(ctx, doc); err != nil {
+			if mongo.IsDuplicateKeyError(err) {
+				return noptions.NoVersion, nerrors.ErrVersionNotMatch
+			}
+			return noptions.NoVersion, err
+		}
+		return 1, nil
+	}
+
+	filter := bson.M{"_id": key.String()}
+	if !o.AnyVersion {
 		filter["version"] = o.Version
-	} else {
-		opt.SetUpsert(true)
 	}
 
 	update := bson.M{
 		"$set": bson.M{"data": o.Source},
 		"$inc": bson.M{"version": 1},
 	}
-
-	res, err := coll.UpdateOne(ctx, filter, update, opt)
-	if err != nil {
-		return 0, err
+	opt := options.FindOneAndUpdate().SetReturnDocument(options.After)
+	if o.AnyVersion {
+		// $inc treats a missing field as 0, so upsert inserts version=1.
+		opt.SetUpsert(true)
 	}
 
-	if res.MatchedCount == 0 && o.Version != noptions.NoVersion {
-		return 0, nerrors.ErrVersionNotMatch
+	res := coll.FindOneAndUpdate(ctx, filter, update, opt)
+	if res.Err() != nil {
+		if errors.Is(res.Err(), mongo.ErrNoDocuments) {
+			return noptions.NoVersion, nerrors.ErrVersionNotMatch
+		}
+		return noptions.NoVersion, res.Err()
 	}
 
-	return o.Version + 1, nil
+	var out struct {
+		Version noptions.Version `bson:"version"`
+	}
+	if err := res.Decode(&out); err != nil {
+		return noptions.NoVersion, err
+	}
+	return out.Version, nil
 }
 
 // Get data from mongoDB
@@ -97,11 +121,12 @@ func (dd *DatabaseDriver) Get(ctx context.Context, key key.Key, opts ...noptions
 func (dd *DatabaseDriver) Delete(ctx context.Context, key key.Key) error {
 	coll := dd.database.Collection(key.Prefix())
 	filter := bson.M{"_id": key.String()}
-	if _, err := coll.DeleteOne(ctx, filter); err != nil {
-		if errors.Is(err, mongo.ErrNoDocuments) {
-			return nerrors.ErrNotFound
-		}
+	res, err := coll.DeleteOne(ctx, filter)
+	if err != nil {
 		return err
+	}
+	if res.DeletedCount == 0 {
+		return nerrors.ErrNotFound
 	}
 	return nil
 }
@@ -111,8 +136,9 @@ func (dd *DatabaseDriver) Incr(ctx context.Context, key key.Key, field string, a
 	coll := dd.database.Collection(key.Prefix())
 	filter := bson.M{"_id": key.String()}
 	update := bson.M{"$inc": bson.M{field: amount}}
-	opt := options.FindOneAndUpdate()
-	opt.SetUpsert(true)
+	opt := options.FindOneAndUpdate().
+		SetUpsert(true).
+		SetReturnDocument(options.After)
 	res := coll.FindOneAndUpdate(ctx, filter, update, opt)
 	if res.Err() != nil {
 		if errors.Is(res.Err(), mongo.ErrNoDocuments) {

--- a/orm/pkg/ofx/mongo_module.go
+++ b/orm/pkg/ofx/mongo_module.go
@@ -10,6 +10,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/gstones/moke-kit/orm/nosql/mongo"
+	"github.com/gstones/moke-kit/utility"
 )
 
 type MongoParams struct {
@@ -51,7 +52,7 @@ func (mr *MongoResult) init(
 		}
 		cOptions.Auth.Password = n.DatabasePassword
 	}
-	l.Info("Connecting mongodb", zap.String("url", n.DatabaseURL))
+	l.Info("Connecting mongodb", zap.String("url", utility.RedactURL(n.DatabaseURL)))
 	client, err := mongo.NewMongoClient(cOptions)
 	if err != nil {
 		l.Error("Failed to connect mongodb", zap.Error(err))

--- a/orm/pkg/ofx/redis_cache_module.go
+++ b/orm/pkg/ofx/redis_cache_module.go
@@ -25,6 +25,10 @@ func (c *RedisCacheResult) init(
 	l *zap.Logger,
 	rParams RedisParams,
 ) error {
+	if rParams.Cache == nil {
+		c.RedisCache = diface.DefaultDocumentCache()
+		return nil
+	}
 	c.RedisCache = cache.CreateRedisCache(l, rParams.Cache)
 	return nil
 }

--- a/orm/pkg/ofx/redis_module.go
+++ b/orm/pkg/ofx/redis_module.go
@@ -10,6 +10,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/gstones/moke-kit/orm/nerrors"
+	"github.com/gstones/moke-kit/utility"
 )
 
 // RedisParams provides the RedisParams to the mfx dependency graph.
@@ -41,7 +42,7 @@ func (rr *RedisResult) init(
 	} else if u, e := url.Parse(n.CacheURL); e != nil {
 		return e
 	} else if u.Scheme != "redis" {
-		l.Error("Invalid redis url", zap.String("url", n.CacheURL))
+		l.Error("Invalid redis url", zap.String("url", utility.RedactURL(n.CacheURL)))
 		return nerrors.ErrInvalidNosqlURL
 	} else {
 		username := u.User.Username()
@@ -65,7 +66,7 @@ func (rr *RedisResult) init(
 			DB:       1,
 		})
 	}
-	l.Info("Connecting redis", zap.String("url", n.CacheURL))
+	l.Info("Connecting redis", zap.String("url", utility.RedactURL(n.CacheURL)))
 	if rr.Redis != nil {
 		lc.Append(fx.Hook{
 			OnStop: func(ctx context.Context) error {

--- a/server/README.md
+++ b/server/README.md
@@ -28,17 +28,27 @@
 
 ### TLS:
 
-| ENV            | Description               | Default                           |
-|----------------|---------------------------|-----------------------------------|
-| MTLS_ENABLE    | enable mTLS mod           | false                             |
-| TLS_ENABLE     | enable server tls         | false                             |
-| TCP_TLS_ENABLE | enable TCP tls            | false                             |
-| CLIENT_CA_CERT | client ca cert path(mTls) | "./configs/tls-client/ca.crt"     |
-| CLIENT_CERT    | client cert path(mTls)    | "./configs/tls-client/client.crt" |
-| CLIENT_KEY     | client key path(mTls)     | "./configs/tls-client/client.key" |
-| SERVER_CA_CERT | server ca cert path       | "./configs/tls-server/ca.crt"     |
-| SERVER_CERT    | server cert path          | "./configs/tls-server/server.crt" |
-| SERVER_KEY     | server key path           | "./configs/tls-server/server.key" |
-| SERVER_NAME    | sever name                | ""                                |   
+| ENV            | Description                                                                 | Default                           |
+|----------------|-----------------------------------------------------------------------------|-----------------------------------|
+| MTLS_ENABLE    | enable mTLS (server TLS + require client certs). Implies TLS for cmux.       | false                             |
+| TLS_ENABLE     | enable server TLS for grpc/http (cmux). Does **not** require client certs.  | false                             |
+| TCP_TLS_ENABLE | enable TCP tls                                                              | false                             |
+| CLIENT_CA_CERT | client ca cert path (required when `MTLS_ENABLE=true`)                      | "./configs/tls-client/ca.crt"     |
+| CLIENT_CERT    | client cert path (used by mTLS clients / gateway dial)                      | "./configs/tls-client/tls.crt"    |
+| CLIENT_KEY     | client key path (used by mTLS clients / gateway dial)                       | "./configs/tls-client/tls.key"    |
+| SERVER_CA_CERT | server ca cert path (used by clients verifying the server)                  | "./configs/tls-server/ca.crt"     |
+| SERVER_CERT    | server cert path                                                            | "./configs/tls-server/tls.crt"    |
+| SERVER_KEY     | server key path                                                             | "./configs/tls-server/tls.key"    |
+| SERVER_NAME    | server name                                                                 | ""                                |
+
+### CORS / Auth:
+
+| ENV                | Description                                                                 | Default |
+|--------------------|-----------------------------------------------------------------------------|---------|
+| CORS_ALLOW_ORIGINS | comma-separated allowed Origins; empty disables CORS; `*` allows any origin | ""      |
+
+Notes:
+* Auth middleware is optional in local/dev. In **prod** deployments (`prod`, `prod_*`, `prod-*`), missing auth middleware fails closed (Unauthenticated).
+* Gateway dials gRPC with TLS/mTLS credentials when `TLS_ENABLE` or `MTLS_ENABLE` is set.
 
 

--- a/server/internal/cmux/cmux.go
+++ b/server/internal/cmux/cmux.go
@@ -32,11 +32,12 @@ func init() {
 // ConnectionMux is the struct for the connection mux.
 // https://github.com/soheilhy/cmux
 type ConnectionMux struct {
-	logger    *zap.Logger
-	listener  net.Listener
-	mux       cmux.CMux
-	port      int32
-	tlsConfig *tls.Config
+	logger     *zap.Logger
+	listener   net.Listener
+	mux        cmux.CMux
+	port       int32
+	tlsConfig  *tls.Config
+	tlsCleanup func()
 }
 
 // GrpcListener returns the grpc listener from the connection mux.
@@ -76,6 +77,7 @@ func (cm *ConnectionMux) init() error {
 		if cm.tlsConfig != nil {
 			listener = tls.NewListener(listener, cm.tlsConfig)
 		}
+		cm.listener = listener
 		cm.mux = cmux.New(listener)
 	}
 	return nil
@@ -105,51 +107,78 @@ func (cm *ConnectionMux) StartServing(_ context.Context) error {
 
 // StopServing stops the connection mux.
 func (cm *ConnectionMux) StopServing(_ context.Context) error {
-	cm.mux.Close()
+	if cm.tlsCleanup != nil {
+		cm.tlsCleanup()
+		cm.tlsCleanup = nil
+	}
+	if cm.mux != nil {
+		cm.mux.Close()
+	}
 	return nil
 }
 
-// NewConnectionMux creates a new connection mux.
-// Watch the tls certificate and reload it when it changes.
-func makeTLSConfig(logger *zap.Logger, tlsCert, tlsKey string, clientCa string) (*tls.Config, error) {
-	if cert, err := tls.LoadX509KeyPair(tlsCert, tlsKey); err != nil {
-		return nil, err
-	} else if caBytes, err := os.ReadFile(clientCa); err != nil {
-		return nil, err
-	} else {
-		ca := x509.NewCertPool()
-		if ok := ca.AppendCertsFromPEM(caBytes); !ok {
-			return nil, fmt.Errorf("failed to parse %v ", clientCa)
-		}
-
-		tlsCertValue := atomic.Value{}
-		tlsCertValue.Store(cert)
-		p, _ := path.Split(tlsCert)
-		if _, err := tools.Watch(logger, p, time.Second*10, func() {
-			logger.Info("service reloading x509 key pair")
-			c, err := tls.LoadX509KeyPair(tlsCert, tlsKey)
-			if err != nil {
-				logger.Error("service failed to load x509 key pair", zap.Error(err))
-				return
-			}
-			tlsCertValue.Store(c)
-		}); err != nil {
-			return nil, err
-		}
-		tlsConfig := &tls.Config{
-			MinVersion: tls.VersionTLS12,
-			ClientAuth: tls.RequireAndVerifyClientCert,
-			GetCertificate: func(info *tls.ClientHelloInfo) (*tls.Certificate, error) {
-				c := tlsCertValue.Load()
-				if c == nil {
-					return nil, fmt.Errorf("certificate not loaded")
-				}
-				res := c.(tls.Certificate)
-				return &res, nil
-			},
-			ClientCAs: ca,
-		}
-		return tlsConfig, nil
+// makeTLSConfig builds a TLS config for the connection mux.
+// When requireClientCert is true, clients must present a cert signed by clientCa.
+// When requireClientCert is false, only server TLS is enabled (clientCa may be empty).
+func makeTLSConfig(
+	logger *zap.Logger,
+	tlsCert, tlsKey string,
+	clientCa string,
+	requireClientCert bool,
+) (*tls.Config, func(), error) {
+	cert, err := tls.LoadX509KeyPair(tlsCert, tlsKey)
+	if err != nil {
+		return nil, nil, err
 	}
 
+	tlsCertValue := atomic.Value{}
+	tlsCertValue.Store(cert)
+	p, _ := path.Split(tlsCert)
+	destroy, err := tools.Watch(logger, p, time.Second*10, func() {
+		logger.Info("service reloading x509 key pair")
+		c, err := tls.LoadX509KeyPair(tlsCert, tlsKey)
+		if err != nil {
+			logger.Error("service failed to load x509 key pair", zap.Error(err))
+			return
+		}
+		tlsCertValue.Store(c)
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+
+	tlsConfig := &tls.Config{
+		MinVersion: tls.VersionTLS12,
+		GetCertificate: func(info *tls.ClientHelloInfo) (*tls.Certificate, error) {
+			c := tlsCertValue.Load()
+			if c == nil {
+				return nil, fmt.Errorf("certificate not loaded")
+			}
+			res := c.(tls.Certificate)
+			return &res, nil
+		},
+	}
+
+	if requireClientCert {
+		if clientCa == "" {
+			destroy()
+			return nil, nil, fmt.Errorf("client CA certificate is required for mTLS")
+		}
+		caBytes, err := os.ReadFile(clientCa)
+		if err != nil {
+			destroy()
+			return nil, nil, err
+		}
+		ca := x509.NewCertPool()
+		if ok := ca.AppendCertsFromPEM(caBytes); !ok {
+			destroy()
+			return nil, nil, fmt.Errorf("failed to parse %v ", clientCa)
+		}
+		tlsConfig.ClientAuth = tls.RequireAndVerifyClientCert
+		tlsConfig.ClientCAs = ca
+	} else {
+		tlsConfig.ClientAuth = tls.NoClientCert
+	}
+
+	return tlsConfig, destroy, nil
 }

--- a/server/internal/cmux/factory.go
+++ b/server/internal/cmux/factory.go
@@ -17,22 +17,23 @@ func NewConnectionMux(
 }
 
 // NewTlsConnectionMux creates a new connection mux with TLS.
+// When mTLS is true, clients must present a certificate signed by clientsCA.
 func NewTlsConnectionMux(
 	logger *zap.Logger,
 	port int32,
 	tlsCert string,
 	tlsKey string,
 	clientsCA string,
+	mTLS bool,
 ) (result *ConnectionMux, err error) {
-	if config, e := makeTLSConfig(logger, tlsCert, tlsKey, clientsCA); e != nil {
-		err = e
-	} else {
-		result = &ConnectionMux{
-			logger:    logger,
-			port:      port,
-			tlsConfig: config,
-		}
+	config, cleanup, e := makeTLSConfig(logger, tlsCert, tlsKey, clientsCA, mTLS)
+	if e != nil {
+		return nil, e
 	}
-
-	return
+	return &ConnectionMux{
+		logger:     logger,
+		port:       port,
+		tlsConfig:  config,
+		tlsCleanup: cleanup,
+	}, nil
 }

--- a/server/internal/srpc/factory.go
+++ b/server/internal/srpc/factory.go
@@ -1,18 +1,34 @@
 package srpc
 
 import (
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
 	"net"
 	"net/http"
+	"os"
+	"strings"
 
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
 
 	"github.com/gstones/moke-kit/server/middlewares"
 	"github.com/gstones/moke-kit/server/siface"
 	"github.com/gstones/moke-kit/utility"
 )
+
+// GatewaySecurity holds TLS settings used when the gateway dials gRPC.
+type GatewaySecurity struct {
+	TLSEnable    bool
+	MTLSEnable   bool
+	ClientCert   string
+	ClientKey    string
+	ServerCaCert string
+	ServerName   string
+}
 
 // NewGrpcServer creates a new grpc server.
 func NewGrpcServer(
@@ -37,22 +53,79 @@ func NewGrpcServer(
 func NewGatewayServer(
 	logger *zap.Logger,
 	listener net.Listener,
+	sec GatewaySecurity,
+	corsAllowOrigins string,
 ) (result *GatewayServer, err error) {
 	mux := runtime.NewServeMux(
 		runtime.WithIncomingHeaderMatcher(matcher),
 		runtime.WithOutgoingHeaderMatcher(matcher),
 	)
-	opts := []grpc.DialOption{grpc.WithTransportCredentials(insecure.NewCredentials())}
+	dialOpts, err := gatewayDialOptions(sec)
+	if err != nil {
+		return nil, err
+	}
+	origins := parseCORSAllowOrigins(corsAllowOrigins)
 	server := &http.Server{
 		Addr:    listener.Addr().String(),
-		Handler: allowCORS(withLogger(mux)),
+		Handler: allowCORS(withLogger(mux), origins),
 	}
 	result = &GatewayServer{
-		logger:   logger,
-		server:   server,
-		mux:      mux,
-		opts:     opts,
-		listener: listener,
+		logger:           logger,
+		server:           server,
+		mux:              mux,
+		opts:             dialOpts,
+		listener:         listener,
+		corsAllowOrigins: origins,
 	}
 	return
+}
+
+func parseCORSAllowOrigins(raw string) []string {
+	if strings.TrimSpace(raw) == "" {
+		return nil
+	}
+	parts := strings.Split(raw, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		if p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+func gatewayDialOptions(sec GatewaySecurity) ([]grpc.DialOption, error) {
+	if !sec.TLSEnable && !sec.MTLSEnable {
+		return []grpc.DialOption{grpc.WithTransportCredentials(insecure.NewCredentials())}, nil
+	}
+
+	tlsConfig := &tls.Config{
+		MinVersion: tls.VersionTLS12,
+	}
+	if sec.ServerName != "" {
+		tlsConfig.ServerName = sec.ServerName
+	}
+	if sec.ServerCaCert != "" {
+		caBytes, err := os.ReadFile(sec.ServerCaCert)
+		if err != nil {
+			return nil, err
+		}
+		ca := x509.NewCertPool()
+		if ok := ca.AppendCertsFromPEM(caBytes); !ok {
+			return nil, fmt.Errorf("failed to parse server CA %q", sec.ServerCaCert)
+		}
+		tlsConfig.RootCAs = ca
+	}
+	if sec.MTLSEnable {
+		if sec.ClientCert == "" || sec.ClientKey == "" {
+			return nil, fmt.Errorf("client certificate and key are required for mTLS gateway dial")
+		}
+		cert, err := tls.LoadX509KeyPair(sec.ClientCert, sec.ClientKey)
+		if err != nil {
+			return nil, err
+		}
+		tlsConfig.Certificates = []tls.Certificate{cert}
+	}
+	return []grpc.DialOption{grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig))}, nil
 }

--- a/server/internal/srpc/gateway.go
+++ b/server/internal/srpc/gateway.go
@@ -15,11 +15,12 @@ import (
 
 // GatewayServer is the struct for the gateway server.
 type GatewayServer struct {
-	logger   *zap.Logger
-	server   *http.Server
-	mux      *runtime.ServeMux
-	listener net.Listener
-	opts     []grpc.DialOption
+	logger           *zap.Logger
+	server           *http.Server
+	mux              *runtime.ServeMux
+	listener         net.Listener
+	opts             []grpc.DialOption
+	corsAllowOrigins []string
 }
 
 // StartServing starts the gateway server.
@@ -72,12 +73,32 @@ func (gs *GatewayServer) Endpoint() string {
 	return gs.server.Addr
 }
 
-func allowCORS(h http.Handler) http.Handler {
+func allowCORS(h http.Handler, allowOrigins []string) http.Handler {
+	allowed := make(map[string]struct{}, len(allowOrigins))
+	allowAll := false
+	for _, o := range allowOrigins {
+		o = strings.TrimSpace(o)
+		if o == "" {
+			continue
+		}
+		if o == "*" {
+			allowAll = true
+			continue
+		}
+		allowed[o] = struct{}{}
+	}
+
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if origin := r.Header.Get("Origin"); origin != "" {
-			w.Header().Set("Access-Control-Allow-Origin", origin)
-			if r.Method == "OPTIONS" && r.Header.Get("Access-Control-Request-Method") != "" {
-				preflightHandler(w, r)
+		origin := r.Header.Get("Origin")
+		if origin != "" {
+			if allowAll {
+				w.Header().Set("Access-Control-Allow-Origin", "*")
+			} else if _, ok := allowed[origin]; ok {
+				w.Header().Set("Access-Control-Allow-Origin", origin)
+				w.Header().Add("Vary", "Origin")
+			}
+			if r.Method == http.MethodOptions && r.Header.Get("Access-Control-Request-Method") != "" {
+				preflightHandler(w, r, allowAll, allowed)
 				return
 			}
 		}
@@ -85,16 +106,25 @@ func allowCORS(h http.Handler) http.Handler {
 	})
 }
 
-func preflightHandler(w http.ResponseWriter, r *http.Request) {
-	if origin := r.Header.Get("Origin"); origin != "" {
+func preflightHandler(w http.ResponseWriter, r *http.Request, allowAll bool, allowed map[string]struct{}) {
+	origin := r.Header.Get("Origin")
+	if allowAll {
+		w.Header().Set("Access-Control-Allow-Origin", "*")
+	} else if _, ok := allowed[origin]; ok {
 		w.Header().Set("Access-Control-Allow-Origin", origin)
+		w.Header().Add("Vary", "Origin")
+	} else {
+		w.WriteHeader(http.StatusForbidden)
+		return
 	}
 
 	headers := []string{"Content-Type", "Accept", "Authorization"}
+	if reqHeaders := r.Header.Get("Access-Control-Request-Headers"); reqHeaders != "" {
+		headers = append(headers, reqHeaders)
+	}
 	w.Header().Set("Access-Control-Allow-Headers", strings.Join(headers, ","))
-
-	methods := []string{"GET", "HEAD", "POST", "PUT", "DELETE"}
-	w.Header().Set("Access-Control-Allow-Methods", strings.Join(methods, ","))
+	w.Header().Set("Access-Control-Allow-Methods", "GET, HEAD, POST, PUT, DELETE, OPTIONS")
+	w.WriteHeader(http.StatusNoContent)
 }
 
 func withLogger(h http.Handler) http.Handler {

--- a/server/internal/srpc/gateway_cors_test.go
+++ b/server/internal/srpc/gateway_cors_test.go
@@ -1,0 +1,47 @@
+package srpc
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestAllowCORSDisabledByDefault(t *testing.T) {
+	h := allowCORS(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}), nil)
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("Origin", "https://evil.example")
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+	if got := rr.Header().Get("Access-Control-Allow-Origin"); got != "" {
+		t.Fatalf("expected no CORS header, got %q", got)
+	}
+}
+
+func TestAllowCORSAllowlist(t *testing.T) {
+	h := allowCORS(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}), []string{"https://app.example"})
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("Origin", "https://app.example")
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+	if got := rr.Header().Get("Access-Control-Allow-Origin"); got != "https://app.example" {
+		t.Fatalf("expected allowlisted origin, got %q", got)
+	}
+}
+
+func TestAllowCORSPreflightRejected(t *testing.T) {
+	h := allowCORS(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatal("should not reach handler")
+	}), []string{"https://app.example"})
+	req := httptest.NewRequest(http.MethodOptions, "/", nil)
+	req.Header.Set("Origin", "https://evil.example")
+	req.Header.Set("Access-Control-Request-Method", "POST")
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+	if rr.Code != http.StatusForbidden {
+		t.Fatalf("expected 403, got %d", rr.Code)
+	}
+}

--- a/server/middlewares/auth.go
+++ b/server/middlewares/auth.go
@@ -5,16 +5,23 @@ import (
 
 	"github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors"
 	"github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/auth"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	"github.com/gstones/moke-kit/server/siface"
+	"github.com/gstones/moke-kit/utility"
 )
 
 // authFunc is a helper function to create a grpc auth interceptor
 // that uses the provided authClient to authenticate incoming requests.
-func authFunc(authClient siface.IAuthMiddleware) auth.AuthFunc {
+// In production deployments, a missing auth middleware fails closed.
+func authFunc(authClient siface.IAuthMiddleware, deployments utility.Deployments) auth.AuthFunc {
 	return func(ctx context.Context) (context.Context, error) {
 		if authClient != nil {
 			return authClient.Auth(ctx)
+		}
+		if deployments.IsProd() {
+			return nil, status.Error(codes.Unauthenticated, "auth middleware is required in production")
 		}
 		return ctx, nil
 	}

--- a/server/middlewares/auth_test.go
+++ b/server/middlewares/auth_test.go
@@ -1,0 +1,33 @@
+package middlewares
+
+import (
+	"context"
+	"testing"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/gstones/moke-kit/utility"
+)
+
+func TestAuthFuncFailClosedInProd(t *testing.T) {
+	fn := authFunc(nil, utility.DeploymentsProd)
+	_, err := fn(context.Background())
+	if err == nil {
+		t.Fatal("expected error in prod without auth middleware")
+	}
+	if status.Code(err) != codes.Unauthenticated {
+		t.Fatalf("expected Unauthenticated, got %v", status.Code(err))
+	}
+}
+
+func TestAuthFuncAllowsNilInNonProd(t *testing.T) {
+	fn := authFunc(nil, utility.DeploymentsLocal)
+	ctx, err := fn(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ctx == nil {
+		t.Fatal("expected context")
+	}
+}

--- a/server/middlewares/grpc_middleware.go
+++ b/server/middlewares/grpc_middleware.go
@@ -28,9 +28,10 @@ func MakeServerOptions(
 ) []grpc.ServerOption {
 
 	rl := CreateRateLimiter(int(rateLimit))
+	af := authFunc(authClient, deployments)
 	ui := []grpc.UnaryServerInterceptor{
 		ratelimit.UnaryServerInterceptor(rl),
-		selector.UnaryServerInterceptor(auth.UnaryServerInterceptor(authFunc(authClient)), selector.MatchFunc(allBut)),
+		selector.UnaryServerInterceptor(auth.UnaryServerInterceptor(af), selector.MatchFunc(allBut)),
 		logging.UnaryServerInterceptor(
 			interceptorLogger(logger),
 			logging.WithLevels(logging.DefaultServerCodeToLevel),
@@ -40,7 +41,7 @@ func MakeServerOptions(
 	}
 	si := []grpc.StreamServerInterceptor{
 		ratelimit.StreamServerInterceptor(rl),
-		selector.StreamServerInterceptor(auth.StreamServerInterceptor(authFunc(authClient)), selector.MatchFunc(allBut)),
+		selector.StreamServerInterceptor(auth.StreamServerInterceptor(af), selector.MatchFunc(allBut)),
 		logging.StreamServerInterceptor(
 			interceptorLogger(logger),
 			logging.WithLevels(logging.DefaultServerCodeToLevel),

--- a/server/pkg/module/binder.go
+++ b/server/pkg/module/binder.go
@@ -142,6 +142,15 @@ func (sb *ServiceBinder) bindGatewayServices(
 	} else if gatewayServer, err := srpc.NewGatewayServer(
 		l,
 		hLis,
+		srpc.GatewaySecurity{
+			TLSEnable:    sb.TLSEnable,
+			MTLSEnable:   sb.MTLSEnable,
+			ClientCert:   sb.ClientCert,
+			ClientKey:    sb.ClientKey,
+			ServerCaCert: sb.ServerCaCert,
+			ServerName:   sb.ServerName,
+		},
+		sb.CorsAllowOrigins,
 	); err != nil {
 		return nil, err
 	} else {

--- a/server/pkg/sfx/cmux_server.go
+++ b/server/pkg/sfx/cmux_server.go
@@ -28,8 +28,16 @@ func (cmr *ConnectionMuxResult) init(
 	g SettingsParams,
 	s SecuritySettingsParams,
 ) error {
-	if s.TLSEnable {
-		mux, err := cmux.NewTlsConnectionMux(l, g.Port, s.ServerCert, s.ServerKey, s.ClientCaCert)
+	// MTLS implies TLS. TLS alone does not require client certificates.
+	if s.TLSEnable || s.MTLSEnable {
+		mux, err := cmux.NewTlsConnectionMux(
+			l,
+			g.Port,
+			s.ServerCert,
+			s.ServerKey,
+			s.ClientCaCert,
+			s.MTLSEnable,
+		)
 		if err != nil {
 			return err
 		}

--- a/server/pkg/sfx/server_settings.go
+++ b/server/pkg/sfx/server_settings.go
@@ -10,10 +10,11 @@ import (
 type SettingsParams struct {
 	fx.In
 
-	Port       int32 `name:"Port"`       // grpc/http port
-	Timeout    int32 `name:"Timeout"`    // tcp service heartbeat timeout
-	RateLimit  int32 `name:"RateLimit"`  // all server type rate limit per second
-	OtelEnable bool  `name:"OtelEnable"` // open telemetry enable
+	Port             int32  `name:"Port"`             // grpc/http port
+	Timeout          int32  `name:"Timeout"`          // tcp service heartbeat timeout
+	RateLimit        int32  `name:"RateLimit"`        // all server type rate limit per second
+	OtelEnable       bool   `name:"OtelEnable"`       // open telemetry enable
+	CorsAllowOrigins string `name:"CorsAllowOrigins"` // comma-separated CORS origins; empty disables CORS; "*" allows all
 
 	//--------------------- zinx settings ---------------------
 	// pure tcp port
@@ -34,10 +35,11 @@ type SettingsParams struct {
 type SettingsResult struct {
 	fx.Out
 
-	Port       int32 `name:"Port"  envconfig:"PORT" default:"8081"`
-	Timeout    int32 `name:"Timeout" envconfig:"TIMEOUT" default:"10"`
-	RateLimit  int32 `name:"RateLimit" envconfig:"RATE_LIMIT" default:"1000"`
-	OtelEnable bool  `name:"OtelEnable" envconfig:"OTEL_ENABLE" default:"false"`
+	Port             int32  `name:"Port"  envconfig:"PORT" default:"8081"`
+	Timeout          int32  `name:"Timeout" envconfig:"TIMEOUT" default:"10"`
+	RateLimit        int32  `name:"RateLimit" envconfig:"RATE_LIMIT" default:"1000"`
+	OtelEnable       bool   `name:"OtelEnable" envconfig:"OTEL_ENABLE" default:"false"`
+	CorsAllowOrigins string `name:"CorsAllowOrigins" envconfig:"CORS_ALLOW_ORIGINS" default:""`
 
 	// --------------------- zinx settings ---------------------
 	ZinxTcpPort int32 `name:"ZinxTcpPort" envconfig:"ZINX_TCP_PORT" default:"8888"`

--- a/test/orm/nosql_test.go
+++ b/test/orm/nosql_test.go
@@ -120,8 +120,23 @@ func TestMockCollection(t *testing.T) {
 		k, err := key.NewKeyFromParts("test", "document", "delete-me")
 		helper.RequireNoError(err)
 
+		_, err = collection.Set(helper.Context(), k, noptions.WithSource(&TestData{Message: "x"}))
+		helper.RequireNoError(err)
+
 		err = collection.Delete(helper.Context(), k)
 		helper.AssertNoError(err)
+
+		err = collection.Delete(helper.Context(), k)
+		helper.AssertNotNil(err, "deleting missing document should fail")
+	})
+
+	t.Run("CreateConflict", func(t *testing.T) {
+		k, err := key.NewKeyFromParts("test", "document", "create-once")
+		helper.RequireNoError(err)
+		_, err = collection.Set(helper.Context(), k, noptions.WithSource(&TestData{Message: "one"}))
+		helper.RequireNoError(err)
+		_, err = collection.Set(helper.Context(), k, noptions.WithSource(&TestData{Message: "two"}))
+		helper.AssertNotNil(err, "create without version should fail if document exists")
 	})
 
 	t.Run("Increment", func(t *testing.T) {
@@ -130,7 +145,11 @@ func TestMockCollection(t *testing.T) {
 
 		newValue, err := collection.Incr(helper.Context(), k, "count", 5)
 		helper.RequireNoError(err)
-		helper.AssertTrue(newValue >= 0)
+		helper.AssertEqual(int64(5), newValue)
+
+		newValue, err = collection.Incr(helper.Context(), k, "count", 3)
+		helper.RequireNoError(err)
+		helper.AssertEqual(int64(8), newValue)
 	})
 }
 

--- a/utility/config.go
+++ b/utility/config.go
@@ -2,15 +2,15 @@ package utility
 
 import (
 	"errors"
-	"log"
 	"reflect"
-	"strings"
 
 	"github.com/hashicorp/vault/api"
 	"github.com/kelseyhightower/envconfig"
 )
 
-// Load from environment and vault
+// Load from environment and vault.
+// When VaultAddr is configured, Vault read failures are returned (fail-closed).
+// When VaultAddr is empty, Vault is skipped and only environment config is used.
 func Load(spec any) error {
 	if err := envconfig.Process("", spec); err != nil {
 		return err
@@ -22,41 +22,64 @@ func Load(spec any) error {
 }
 
 func loadFromVault(spec any) error {
-	if !reflect.ValueOf(spec).Elem().FieldByName("VaultAddr").IsValid() {
+	rv := reflect.ValueOf(spec)
+	if rv.Kind() != reflect.Ptr || rv.IsNil() || rv.Elem().Kind() != reflect.Struct {
 		return nil
 	}
-	conf := &api.Config{
-		Address: reflect.ValueOf(spec).Elem().FieldByName("VaultAddr").String(),
+	elem := rv.Elem()
+	addrField := elem.FieldByName("VaultAddr")
+	if !addrField.IsValid() || addrField.Kind() != reflect.String {
+		return nil
 	}
+	vaultAddr := addrField.String()
+	if vaultAddr == "" {
+		return nil
+	}
+
+	tokenField := elem.FieldByName("VaultToken")
+	pathField := elem.FieldByName("VaultPath")
+	if !tokenField.IsValid() || tokenField.Kind() != reflect.String ||
+		!pathField.IsValid() || pathField.Kind() != reflect.String {
+		return errors.New("vault config requires VaultToken and VaultPath string fields")
+	}
+	vaultToken := tokenField.String()
+	vaultPath := pathField.String()
+	if vaultToken == "" || vaultPath == "" {
+		return errors.New("vault token and path are required when VaultAddr is set")
+	}
+
+	conf := &api.Config{Address: vaultAddr}
 	client, err := api.NewClient(conf)
 	if err != nil {
 		return err
 	}
-	client.SetToken(reflect.ValueOf(spec).Elem().FieldByName("VaultToken").String())
-	secret, err := client.Logical().Read(reflect.ValueOf(spec).Elem().FieldByName("VaultPath").String())
+	client.SetToken(vaultToken)
+	secret, err := client.Logical().Read(vaultPath)
 	if err != nil {
-		if strings.Contains(err.Error(), "connect: connection refused") ||
-			strings.Contains(err.Error(), "connect: connection timed out") {
-			log.Println("vault address cannot be connected, only environment configuration available")
-			return nil
-		} else if strings.Contains(err.Error(), "permission denied") {
-			log.Println("vault token is invalid, only environment configuration available")
-			return nil
-		}
 		return err
 	}
-	m, ok := secret.Data["data"].(map[string]any)
-	if !ok {
-		return errors.New("can't read from vault")
+	if secret == nil || secret.Data == nil {
+		return errors.New("can't read from vault: empty secret")
 	}
-	t := reflect.TypeOf(spec).Elem()
+
+	data := secret.Data
+	if nested, ok := secret.Data["data"].(map[string]any); ok {
+		data = nested
+	}
+
+	t := elem.Type()
 	num := t.NumField()
 	for i := 0; i < num; i++ {
 		key := t.Field(i).Tag.Get("vault")
-		if key != "" && m[key] != nil {
-			if strVal, ok := m[key].(string); ok {
-				reflect.ValueOf(spec).Elem().FieldByName(t.Field(i).Name).SetString(strVal)
-			}
+		if key == "" || data[key] == nil {
+			continue
+		}
+		field := elem.FieldByName(t.Field(i).Name)
+		if !field.IsValid() || !field.CanSet() || field.Kind() != reflect.String {
+			continue
+		}
+		if strVal, ok := data[key].(string); ok {
+			field.SetString(strVal)
 		}
 	}
 	return nil

--- a/utility/config_test.go
+++ b/utility/config_test.go
@@ -1,0 +1,31 @@
+package utility
+
+import "testing"
+
+func TestLoadSkipsVaultWhenAddrEmpty(t *testing.T) {
+	type cfg struct {
+		Name       string `envconfig:"TEST_CFG_NAME" default:"ok"`
+		VaultAddr  string `envconfig:"TEST_CFG_VAULT_ADDR" default:""`
+		VaultToken string `envconfig:"TEST_CFG_VAULT_TOKEN" default:""`
+		VaultPath  string `envconfig:"TEST_CFG_VAULT_PATH" default:""`
+	}
+	var c cfg
+	if err := Load(&c); err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if c.Name != "ok" {
+		t.Fatalf("expected default name, got %q", c.Name)
+	}
+}
+
+func TestLoadFailsClosedWhenVaultConfiguredButIncomplete(t *testing.T) {
+	type cfg struct {
+		VaultAddr  string `envconfig:"TEST_CFG2_VAULT_ADDR" default:"http://127.0.0.1:8200"`
+		VaultToken string `envconfig:"TEST_CFG2_VAULT_TOKEN" default:""`
+		VaultPath  string `envconfig:"TEST_CFG2_VAULT_PATH" default:""`
+	}
+	var c cfg
+	if err := Load(&c); err == nil {
+		t.Fatal("expected error when VaultAddr set without token/path")
+	}
+}

--- a/utility/deployment.go
+++ b/utility/deployment.go
@@ -14,22 +14,33 @@ func (d Deployments) String() string {
 	return string(d)
 }
 
-// IsProd returns true if the deployment contains "prod", e.g. "prod", "prod_gcp", "prod_aws"... etc
+// matchDeployment reports whether d equals name or uses name as a prefix
+// followed by '_' or '-' (e.g. prod, prod_gcp, prod-aws).
+func matchDeployment(d Deployments, name string) bool {
+	s := d.String()
+	if s == name {
+		return true
+	}
+	return strings.HasPrefix(s, name+"_") || strings.HasPrefix(s, name+"-")
+}
+
+// IsProd returns true for "prod" and variants like "prod_gcp", "prod-aws".
 func (d Deployments) IsProd() bool {
-	return strings.Contains(d.String(), DeploymentsProd.String())
+	return matchDeployment(d, DeploymentsProd.String())
 }
 
-// IsDev returns true if the deployment contains "dev", e.g. "dev", "dev_test", "dev_load"... etc
+// IsDev returns true for "dev" and variants like "dev_test", "dev-load".
 func (d Deployments) IsDev() bool {
-	return strings.Contains(d.String(), DeploymentsDev.String())
+	return matchDeployment(d, DeploymentsDev.String())
 }
 
-// IsLocal returns true if the deployment contains "local", e.g. "local", "local_67", "local_name"... etc
+// IsLocal returns true for "local" and variants like "local_67", "local-name".
 func (d Deployments) IsLocal() bool {
-	return strings.Contains(d.String(), DeploymentsLocal.String())
+	return matchDeployment(d, DeploymentsLocal.String())
 }
 
 func ParseDeployments(value string) Deployments {
+	value = strings.ToLower(strings.TrimSpace(value))
 	switch Deployments(value) {
 	case DeploymentsLocal:
 		return DeploymentsLocal

--- a/utility/deployment_test.go
+++ b/utility/deployment_test.go
@@ -1,0 +1,39 @@
+package utility
+
+import "testing"
+
+func TestParseDeploymentsNormalization(t *testing.T) {
+	if got := ParseDeployments(" PROD "); got != DeploymentsProd {
+		t.Fatalf("expected prod, got %q", got)
+	}
+	if got := ParseDeployments("Dev"); got != DeploymentsDev {
+		t.Fatalf("expected dev, got %q", got)
+	}
+}
+
+func TestDeploymentMatchers(t *testing.T) {
+	cases := []struct {
+		value        string
+		prod, dev, local bool
+	}{
+		{"prod", true, false, false},
+		{"prod_gcp", true, false, false},
+		{"prod-aws", true, false, false},
+		{"production", false, false, false},
+		{"notprod", false, false, false},
+		{"nonprod", false, false, false},
+		{"dev", false, true, false},
+		{"dev_test", false, true, false},
+		{"development", false, false, false},
+		{"local", false, false, true},
+		{"local_67", false, false, true},
+		{"localprod", false, false, false},
+	}
+	for _, tc := range cases {
+		d := ParseDeployments(tc.value)
+		if d.IsProd() != tc.prod || d.IsDev() != tc.dev || d.IsLocal() != tc.local {
+			t.Fatalf("%q: got prod=%v dev=%v local=%v, want prod=%v dev=%v local=%v",
+				tc.value, d.IsProd(), d.IsDev(), d.IsLocal(), tc.prod, tc.dev, tc.local)
+		}
+	}
+}

--- a/utility/deployment_test.go
+++ b/utility/deployment_test.go
@@ -13,7 +13,7 @@ func TestParseDeploymentsNormalization(t *testing.T) {
 
 func TestDeploymentMatchers(t *testing.T) {
 	cases := []struct {
-		value        string
+		value            string
 		prod, dev, local bool
 	}{
 		{"prod", true, false, false},

--- a/utility/url.go
+++ b/utility/url.go
@@ -1,0 +1,45 @@
+package utility
+
+import (
+	"net/url"
+	"strings"
+)
+
+// RedactURL returns a copy of rawURL with userinfo credentials removed.
+// If parsing fails, a best-effort string scrub is returned.
+func RedactURL(rawURL string) string {
+	if rawURL == "" {
+		return ""
+	}
+	u, err := url.Parse(rawURL)
+	if err != nil || u.Scheme == "" {
+		return scrubUserinfo(rawURL)
+	}
+	if u.User != nil {
+		username := u.User.Username()
+		if _, hasPassword := u.User.Password(); hasPassword {
+			u.User = url.UserPassword(username, "xxxxx")
+		} else if username != "" {
+			u.User = url.User(username)
+		}
+	}
+	return u.String()
+}
+
+func scrubUserinfo(rawURL string) string {
+	schemeIdx := strings.Index(rawURL, "://")
+	if schemeIdx < 0 {
+		return rawURL
+	}
+	rest := rawURL[schemeIdx+3:]
+	at := strings.Index(rest, "@")
+	if at < 0 {
+		return rawURL
+	}
+	cred := rest[:at]
+	hostPart := rest[at+1:]
+	if colon := strings.Index(cred, ":"); colon >= 0 {
+		return rawURL[:schemeIdx+3] + cred[:colon] + ":xxxxx@" + hostPart
+	}
+	return rawURL[:schemeIdx+3] + cred + "@" + hostPart
+}

--- a/utility/url_test.go
+++ b/utility/url_test.go
@@ -1,0 +1,24 @@
+package utility
+
+import "testing"
+
+func TestRedactURL(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"empty", "", ""},
+		{"no userinfo", "mongodb://localhost:27017/db", "mongodb://localhost:27017/db"},
+		{"password", "redis://user:secret@host:6379/0", "redis://user:xxxxx@host:6379/0"},
+		{"username only", "nats://user@host:4222", "nats://user@host:4222"},
+		{"mongo srv", "mongodb+srv://u:p@cluster.example/db", "mongodb+srv://u:xxxxx@cluster.example/db"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := RedactURL(tt.in); got != tt.want {
+				t.Fatalf("RedactURL(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Addresses the high/medium findings from a full-repo review of moke-kit.

### Correctness
- **NATS/local MQ**: `Subscribe` now returns a cancelable `Subscription` (no more `nil, nil`); unsubscribe cancels only that subscription.
- **Mongo driver**: `Set` create-only / CAS / `WithAnyVersion` semantics match the interface docs; `Delete` returns `ErrNotFound` when missing; `Incr` returns the post-update value.
- **Mock collection**: Per-key storage with matching CAS/create/delete/incr behavior.

### Security / defaults
- **TLS vs mTLS**: `TLS_ENABLE` enables server TLS only; `MTLS_ENABLE` requires client certs (and implies TLS).
- **Gateway**: dials gRPC with TLS/mTLS credentials when enabled; CORS is allowlist-based via `CORS_ALLOW_ORIGINS` (empty = disabled, `*` = any).
- **Auth**: missing auth middleware fails closed in prod deployments.
- **Vault**: when `VaultAddr` is set, failures no longer silently fall back.
- **Logs**: Mongo/Redis/NATS URLs are redacted before logging.

### Reliability
- TLS cert watcher cleanup on cmux stop.
- Redis cache falls back to no-op when Redis client is nil.
- Deployment helpers use exact/prefix matching (`prod`, `prod_*`, `prod-*`) instead of substring.

### Tests
Added package tests for URL redaction, deployment matching, Vault fail-closed, MQ subscription, auth fail-closed, CORS, and nil Redis cache.

## Test plan
- [x] `go test ./...`
- [x] `go test -race` on changed packages
- [x] `go build ./...`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a7c63fff-b27a-4ad1-b530-d99fe3e18a69?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a7c63fff-b27a-4ad1-b530-d99fe3e18a69&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

