### PR TITLE
docs: refresh COMPATIBILITY after #226 and platform/game merges

### DIFF
--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -5,12 +5,13 @@ reference platform and game repositories.
 
 | moke-kit version | platform | game | Notes |
 | --- | --- | --- | --- |
-| `v1.0.5-0.20260811094419-bcdfe55515cd` (#224) | [platform#24](https://github.com/moke-game/platform/pull/24)+ | [game#19](https://github.com/moke-game/game/pull/19)+ | Subscribe/CAS/CORS/TLS/Auth + binder fail-closed |
+| `v1.0.5-0.20260811094419-bcdfe55515cd` (#224) + create-game [#226](https://github.com/GStones/moke-kit/pull/226) | [platform#25](https://github.com/moke-game/platform/pull/25) | [game#20](https://github.com/moke-game/game/pull/20) | Binder fail-closed + scaffold auth defaults |
+| `v1.0.5-0.20260811094419-bcdfe55515cd` (#224) | [platform#24](https://github.com/moke-game/platform/pull/24) | [game#19](https://github.com/moke-game/game/pull/19) | Subscribe/CAS/CORS/TLS/Auth + binder fail-closed |
 | `v1.0.5-0.20260811085843-60e104db6db7` (#221) | platform#24 base | game#19 base | Request-path auth fail-closed only |
 | `v1.0.4` | older | older | Pre-hardening |
 
-`create-game` skill templates follow game secure defaults (no `WithoutAuth` on public
-services, AuthModule stub, gRPC+HTTP default, TCP opt-in, cancelable Watch).
+`create-game` skill templates follow game secure defaults (`AllModule` + stub auth in
+`main`, no `WithoutAuth` on public services, gRPC+HTTP default, TCP opt-in, cancelable Watch).
 
 ## Tracking issues
 

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -5,6 +5,7 @@ reference platform and game repositories.
 
 | moke-kit version | platform | game | Notes |
 | --- | --- | --- | --- |
+| `v1.0.5-0.20260812022140-acb9f313d7fd` ([#228](https://github.com/GStones/moke-kit/pull/228)) | [platform#27](https://github.com/moke-game/platform/pull/27) | [game#22](https://github.com/moke-game/game/pull/22) | CAS/StopServing/MQ race tests + CI lint/vuln; platform jwt/v5 + CAS/chat lifecycle |
 | `v1.0.5-0.20260811094419-bcdfe55515cd` (#224) + create-game [#226](https://github.com/GStones/moke-kit/pull/226) | [platform#25](https://github.com/moke-game/platform/pull/25) | [game#20](https://github.com/moke-game/game/pull/20) | Binder fail-closed + scaffold auth defaults |
 | `v1.0.5-0.20260811094419-bcdfe55515cd` (#224) | [platform#24](https://github.com/moke-game/platform/pull/24) | [game#19](https://github.com/moke-game/game/pull/19) | Subscribe/CAS/CORS/TLS/Auth + binder fail-closed |
 | `v1.0.5-0.20260811085843-60e104db6db7` (#221) | platform#24 base | game#19 base | Request-path auth fail-closed only |
@@ -12,6 +13,8 @@ reference platform and game repositories.
 
 `create-game` skill templates follow game secure defaults (`AllModule` + stub auth in
 `main`, no `WithoutAuth` on public services, gRPC+HTTP default, TCP opt-in, cancelable Watch).
+
+Consumers may still pin `go.mod` to `#224` while `#228` lands on `main`; bump when you need the StopServing deadline behavior or want CI parity.
 
 ## Tracking issues
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Post-merge cleanup after [#226](https://github.com/GStones/moke-kit/pull/226) and related platform/game merges.

### Changes
- Matrix row for create-game [#226] + platform#25 / game#20
- Clarify scaffold auth defaults (`AllModule` + stub in `main`)

### Test plan
- [x] Docs-only
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-398a3149-3eb1-4944-b716-74b5ecd93293?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-398a3149-3eb1-4944-b716-74b5ecd93293&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

