### PR TITLE
feat: collection CAS contracts and context-aware gRPC stop

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -4,6 +4,7 @@ jobs:
   test:
     permissions:
       contents: read
+      pull-requests: read
     name: Test
     runs-on: ubuntu-latest
     steps:
@@ -22,7 +23,7 @@ jobs:
         run: go vet ./...
 
       - name: govulncheck
-        run: go run golang.org/x/vuln/cmd/govulncheck@latest ./...
+        run: go run golang.org/x/vuln/cmd/govulncheck@v1.6.0 ./...
 
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v8

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,26 +1,33 @@
 name: Go
 on: [pull_request]
 jobs:
-
   test:
     permissions:
       contents: read
     name: Test
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
-    - uses: actions/checkout@v3
-      with:
-        fetch-depth: 50 # Need git history for testing.
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: "go.mod"
 
-    - uses: actions/setup-go@v4
-      with:
-        go-version-file: "go.mod"
+      - name: Test
+        run: go test -v -race -coverpkg=./... -coverprofile=coverage.txt ./...
 
-    - name: Test
-      run: go test -v -race -coverpkg=./... -coverprofile=coverage.txt ./...
+      - name: Vet
+        run: go vet ./...
 
-    - name: Vet
-      run: go vet ./...
+      - name: govulncheck
+        run: go run golang.org/x/vuln/cmd/govulncheck@latest ./...
 
-    - uses: codecov/codecov-action@v3
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v8
+        with:
+          version: v2.12.2
+          only-new-issues: true
+
+      - uses: codecov/codecov-action@v3

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,19 @@
+version: "2"
+
+run:
+  timeout: 5m
+
+linters:
+  default: none
+  enable:
+    - errcheck
+    - govet
+    - ineffassign
+    - staticcheck
+    - unused
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/mq/internal/local/concurrent_lifecycle_test.go
+++ b/mq/internal/local/concurrent_lifecycle_test.go
@@ -1,0 +1,54 @@
+package local
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"go.uber.org/zap"
+
+	"github.com/gstones/moke-kit/mq/common"
+	"github.com/gstones/moke-kit/mq/miface"
+)
+
+func TestConcurrentPublishAndUnsubscribe(t *testing.T) {
+	t.Parallel()
+	mq := NewMessageQueue(zap.NewNop(), 64, false, false)
+
+	var received atomic.Int32
+	sub, err := mq.Subscribe(context.Background(), "race-topic", func(msg miface.Message, err error) common.ConsumptionCode {
+		received.Add(1)
+		return common.ConsumeAck
+	})
+	if err != nil {
+		t.Fatalf("Subscribe: %v", err)
+	}
+
+	const publishers = 8
+	const messages = 20
+	var wg sync.WaitGroup
+	wg.Add(publishers + 1)
+	go func() {
+		defer wg.Done()
+		time.Sleep(5 * time.Millisecond)
+		_ = sub.Unsubscribe()
+	}()
+	for i := 0; i < publishers; i++ {
+		go func() {
+			defer wg.Done()
+			for j := 0; j < messages; j++ {
+				_ = mq.Publish("race-topic", miface.WithBytes([]byte("x")))
+			}
+		}()
+	}
+	wg.Wait()
+
+	// Drain briefly; goal is race-detector cleanliness, not exact delivery count.
+	time.Sleep(50 * time.Millisecond)
+	_ = received.Load()
+	if sub.IsValid() {
+		t.Fatal("expected subscription invalid after Unsubscribe")
+	}
+}

--- a/mq/internal/local/concurrent_lifecycle_test.go
+++ b/mq/internal/local/concurrent_lifecycle_test.go
@@ -18,7 +18,10 @@ func TestConcurrentPublishAndUnsubscribe(t *testing.T) {
 	mq := NewMessageQueue(zap.NewNop(), 64, false, false)
 
 	var received atomic.Int32
+	started := make(chan struct{})
+	var once sync.Once
 	sub, err := mq.Subscribe(context.Background(), "race-topic", func(msg miface.Message, err error) common.ConsumptionCode {
+		once.Do(func() { close(started) })
 		received.Add(1)
 		return common.ConsumeAck
 	})
@@ -27,14 +30,23 @@ func TestConcurrentPublishAndUnsubscribe(t *testing.T) {
 	}
 
 	const publishers = 8
-	const messages = 20
+	const messages = 40
 	var wg sync.WaitGroup
-	wg.Add(publishers + 1)
+	wg.Add(publishers)
+
+	// Unsubscribe only after the first message is observed, so publish/unsub overlap under -race.
+	unsubDone := make(chan struct{})
 	go func() {
-		defer wg.Done()
-		time.Sleep(5 * time.Millisecond)
+		defer close(unsubDone)
+		select {
+		case <-started:
+		case <-time.After(2 * time.Second):
+			t.Error("timed out waiting for first message before Unsubscribe")
+			return
+		}
 		_ = sub.Unsubscribe()
 	}()
+
 	for i := 0; i < publishers; i++ {
 		go func() {
 			defer wg.Done()
@@ -44,11 +56,12 @@ func TestConcurrentPublishAndUnsubscribe(t *testing.T) {
 		}()
 	}
 	wg.Wait()
+	<-unsubDone
 
-	// Drain briefly; goal is race-detector cleanliness, not exact delivery count.
-	time.Sleep(50 * time.Millisecond)
-	_ = received.Load()
 	if sub.IsValid() {
 		t.Fatal("expected subscription invalid after Unsubscribe")
+	}
+	if received.Load() == 0 {
+		t.Fatal("expected at least one message before Unsubscribe")
 	}
 }

--- a/mq/internal/subscription/subscription_test.go
+++ b/mq/internal/subscription/subscription_test.go
@@ -1,6 +1,10 @@
 package subscription
 
-import "testing"
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+)
 
 func TestCancelSubscription(t *testing.T) {
 	called := false
@@ -20,5 +24,31 @@ func TestCancelSubscription(t *testing.T) {
 	// idempotent
 	if err := sub.Unsubscribe(); err != nil {
 		t.Fatalf("second Unsubscribe error: %v", err)
+	}
+}
+
+func TestCancelSubscriptionConcurrentUnsubscribe(t *testing.T) {
+	t.Parallel()
+	var cancels atomic.Int32
+	sub := NewCancelSubscription(func() { cancels.Add(1) })
+
+	const n = 32
+	var wg sync.WaitGroup
+	wg.Add(n)
+	for i := 0; i < n; i++ {
+		go func() {
+			defer wg.Done()
+			if err := sub.Unsubscribe(); err != nil {
+				t.Errorf("Unsubscribe: %v", err)
+			}
+		}()
+	}
+	wg.Wait()
+
+	if cancels.Load() != 1 {
+		t.Fatalf("cancel calls=%d want 1", cancels.Load())
+	}
+	if sub.IsValid() {
+		t.Fatal("expected invalid after concurrent unsubscribe")
 	}
 }

--- a/server/internal/srpc/grpc.go
+++ b/server/internal/srpc/grpc.go
@@ -39,6 +39,7 @@ func (gs *GrpcServer) StartServing(_ context.Context) error {
 
 // StopServing stops the grpc server.
 // Honors ctx: if the deadline/cancel fires before GracefulStop finishes, force Stop().
+// When GracefulStop and ctx fire together, prefer success (nil) over ctx.Err().
 func (gs *GrpcServer) StopServing(ctx context.Context) error {
 	stopped := make(chan struct{})
 	go func() {
@@ -49,6 +50,12 @@ func (gs *GrpcServer) StopServing(ctx context.Context) error {
 	case <-stopped:
 		return nil
 	case <-ctx.Done():
+		// Prefer graceful success if it completed in the same instant.
+		select {
+		case <-stopped:
+			return nil
+		default:
+		}
 		gs.server.Stop()
 		<-stopped
 		return ctx.Err()

--- a/server/internal/srpc/grpc.go
+++ b/server/internal/srpc/grpc.go
@@ -38,9 +38,21 @@ func (gs *GrpcServer) StartServing(_ context.Context) error {
 }
 
 // StopServing stops the grpc server.
-func (gs *GrpcServer) StopServing(_ context.Context) error {
-	gs.server.GracefulStop()
-	return nil
+// Honors ctx: if the deadline/cancel fires before GracefulStop finishes, force Stop().
+func (gs *GrpcServer) StopServing(ctx context.Context) error {
+	stopped := make(chan struct{})
+	go func() {
+		gs.server.GracefulStop()
+		close(stopped)
+	}()
+	select {
+	case <-stopped:
+		return nil
+	case <-ctx.Done():
+		gs.server.Stop()
+		<-stopped
+		return ctx.Err()
+	}
 }
 
 // GrpcServer returns the grpc server.

--- a/server/internal/srpc/grpc_stop_test.go
+++ b/server/internal/srpc/grpc_stop_test.go
@@ -97,7 +97,7 @@ func TestGrpcServerStopServingForceWhenRPCBlocks(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer conn.Close()
+	defer func() { _ = conn.Close() }()
 
 	invokeDone := make(chan error, 1)
 	go func() {

--- a/server/internal/srpc/grpc_stop_test.go
+++ b/server/internal/srpc/grpc_stop_test.go
@@ -2,15 +2,29 @@ package srpc
 
 import (
 	"context"
+	"errors"
 	"net"
 	"testing"
 	"time"
 
 	"go.uber.org/zap/zaptest"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/protobuf/types/known/emptypb"
 )
 
-func TestGrpcServerStopServingHonorsContext(t *testing.T) {
+type hangService interface {
+	isHang()
+}
+
+type hangServer struct {
+	started chan struct{}
+	release chan struct{}
+}
+
+func (*hangServer) isHang() {}
+
+func TestGrpcServerStopServingIdle(t *testing.T) {
 	t.Parallel()
 
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
@@ -33,24 +47,81 @@ func TestGrpcServerStopServingHonorsContext(t *testing.T) {
 	}
 }
 
-func TestGrpcServerStopServingForceOnCancel(t *testing.T) {
+func TestGrpcServerStopServingForceWhenRPCBlocks(t *testing.T) {
 	t.Parallel()
 
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		t.Fatal(err)
 	}
+
+	hang := &hangServer{
+		started: make(chan struct{}),
+		release: make(chan struct{}),
+	}
+	s := grpc.NewServer()
+	s.RegisterService(&grpc.ServiceDesc{
+		ServiceName: "test.Hang",
+		HandlerType: (*hangService)(nil),
+		Methods: []grpc.MethodDesc{{
+			MethodName: "Wait",
+			Handler: func(srv any, ctx context.Context, dec func(any) error, _ grpc.UnaryServerInterceptor) (any, error) {
+				if err := dec(new(emptypb.Empty)); err != nil {
+					return nil, err
+				}
+				h := srv.(*hangServer)
+				close(h.started)
+				select {
+				case <-h.release:
+					return &emptypb.Empty{}, nil
+				case <-ctx.Done():
+					return nil, ctx.Err()
+				}
+			},
+		}},
+	}, hang)
+
 	gs := &GrpcServer{
 		logger:   zaptest.NewLogger(t),
-		server:   grpc.NewServer(),
+		server:   s,
 		listener: ln,
 	}
 	if err := gs.StartServing(context.Background()); err != nil {
 		t.Fatal(err)
 	}
 
-	// Already-cancelled ctx should force Stop path (may still return ctx.Err()).
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
-	_ = gs.StopServing(ctx)
+	conn, err := grpc.NewClient(
+		ln.Addr().String(),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+
+	invokeDone := make(chan error, 1)
+	go func() {
+		invokeDone <- conn.Invoke(context.Background(), "/test.Hang/Wait", &emptypb.Empty{}, &emptypb.Empty{})
+	}()
+
+	select {
+	case <-hang.started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("RPC did not start")
+	}
+
+	// GracefulStop cannot finish while Hang/Wait is in flight; force Stop via short deadline.
+	ctx, cancel := context.WithTimeout(context.Background(), 150*time.Millisecond)
+	defer cancel()
+	err = gs.StopServing(ctx)
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("StopServing err=%v want deadline exceeded", err)
+	}
+
+	close(hang.release)
+	select {
+	case <-invokeDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("client Invoke did not return after force stop")
+	}
 }

--- a/server/internal/srpc/grpc_stop_test.go
+++ b/server/internal/srpc/grpc_stop_test.go
@@ -1,0 +1,56 @@
+package srpc
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+
+	"go.uber.org/zap/zaptest"
+	"google.golang.org/grpc"
+)
+
+func TestGrpcServerStopServingHonorsContext(t *testing.T) {
+	t.Parallel()
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	gs := &GrpcServer{
+		logger:   zaptest.NewLogger(t),
+		server:   grpc.NewServer(),
+		listener: ln,
+	}
+	if err := gs.StartServing(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	if err := gs.StopServing(ctx); err != nil {
+		t.Fatalf("StopServing: %v", err)
+	}
+}
+
+func TestGrpcServerStopServingForceOnCancel(t *testing.T) {
+	t.Parallel()
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	gs := &GrpcServer{
+		logger:   zaptest.NewLogger(t),
+		server:   grpc.NewServer(),
+		listener: ln,
+	}
+	if err := gs.StartServing(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+
+	// Already-cancelled ctx should force Stop path (may still return ctx.Err()).
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_ = gs.StopServing(ctx)
+}

--- a/test/orm/nosql_test.go
+++ b/test/orm/nosql_test.go
@@ -151,6 +151,59 @@ func TestMockCollection(t *testing.T) {
 		helper.RequireNoError(err)
 		helper.AssertEqual(int64(8), newValue)
 	})
+
+	t.Run("CASWithVersion", func(t *testing.T) {
+		k, err := key.NewKeyFromParts("test", "document", "cas")
+		helper.RequireNoError(err)
+
+		v1, err := collection.Set(helper.Context(), k, noptions.WithSource(&TestData{Message: "a", Count: 1}))
+		helper.RequireNoError(err)
+
+		v2, err := collection.Set(
+			helper.Context(),
+			k,
+			noptions.WithSource(&TestData{Message: "b", Count: 2}),
+			noptions.WithVersion(v1),
+		)
+		helper.RequireNoError(err)
+		helper.AssertTrue(v2 > v1)
+
+		_, err = collection.Set(
+			helper.Context(),
+			k,
+			noptions.WithSource(&TestData{Message: "stale", Count: 99}),
+			noptions.WithVersion(v1),
+		)
+		helper.AssertNotNil(err, "stale version must fail CAS")
+
+		var got TestData
+		_, err = collection.Get(helper.Context(), k, noptions.WithDestination(&got))
+		helper.RequireNoError(err)
+		helper.AssertEqual("b", got.Message)
+		helper.AssertEqual(2, got.Count)
+	})
+
+	t.Run("AnyVersionOverwrite", func(t *testing.T) {
+		k, err := key.NewKeyFromParts("test", "document", "any-version")
+		helper.RequireNoError(err)
+
+		_, err = collection.Set(helper.Context(), k, noptions.WithSource(&TestData{Message: "old", Count: 1}))
+		helper.RequireNoError(err)
+
+		_, err = collection.Set(
+			helper.Context(),
+			k,
+			noptions.WithSource(&TestData{Message: "new", Count: 7}),
+			noptions.WithAnyVersion(),
+		)
+		helper.RequireNoError(err)
+
+		var got TestData
+		_, err = collection.Get(helper.Context(), k, noptions.WithDestination(&got))
+		helper.RequireNoError(err)
+		helper.AssertEqual("new", got.Message)
+		helper.AssertEqual(7, got.Count)
+	})
 }
 
 // TestNoSQLOptions tests the NoSQL options

--- a/test/orm/nosql_test.go
+++ b/test/orm/nosql_test.go
@@ -2,12 +2,14 @@ package orm
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zaptest"
 
+	"github.com/gstones/moke-kit/orm/nerrors"
 	"github.com/gstones/moke-kit/orm/nosql/diface"
 	"github.com/gstones/moke-kit/orm/nosql/key"
 	"github.com/gstones/moke-kit/orm/nosql/mock"
@@ -174,7 +176,7 @@ func TestMockCollection(t *testing.T) {
 			noptions.WithSource(&TestData{Message: "stale", Count: 99}),
 			noptions.WithVersion(v1),
 		)
-		helper.AssertNotNil(err, "stale version must fail CAS")
+		helper.AssertTrue(errors.Is(err, nerrors.ErrVersionNotMatch), "stale version must fail CAS")
 
 		var got TestData
 		_, err = collection.Get(helper.Context(), k, noptions.WithDestination(&got))


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Continues [kit#223](https://github.com/GStones/moke-kit/issues/223) after #224/#226.

### Changes
- Mock `ICollection` contract tests: `WithVersion` CAS (stale fails) + `WithAnyVersion` overwrite
- `GrpcServer.StopServing` honors stop context — force `Stop()` if `GracefulStop` outlives the deadline

### Test plan
- [x] `go test ./server/internal/srpc/ ./test/orm/ -count=1`
- [ ] CI green

Related: [platform CAS/chat tests](https://github.com/moke-game/platform/compare/main...cursor/issue-23-cas-chat-tests-3293)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-398a3149-3eb1-4944-b716-74b5ecd93293?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-398a3149-3eb1-4944-b716-74b5ecd93293&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

