### PR TITLE
feat(create-game): align thin topology and auth-free transport modules

### DIFF
--- a/.agents/skills/create-game/assets/template/.env.example.tmpl
+++ b/.agents/skills/create-game/assets/template/.env.example.tmpl
@@ -1,26 +1,52 @@
 # Game template environment (copy to .env and adjust)
 
+# --- App ---
 APP_NAME=__NAME__
 APP_ID=__NAME__
 DEPLOYMENT=local
 VERSION=0.0.1
 
-# Stub AuthModule requires a bearer and sets UIDContextKey from that token.
+# --- Auth ---
+# Stub AuthModule (default main) requires a bearer and sets UIDContextKey from that token.
 # For real ValidateToken, swap dfx.AuthModule in main for platform
 # AuthMiddlewareModule / AuthAllModule (do not keep both) and set:
-# AUTH_URL=localhost:8081
-# JWT_TOKEN_SECRET=change-me-in-prod
+AUTH_URL=localhost:8081
+AUTH_STORE_NAME=auth
+JWT_TOKEN_SECRET=change-me-in-prod
+JWT_TOKEN_EXPIRE=12
+# Thin topology: override AUTH_URL to the remote AuthService; never point it at
+# this process's PORT unless AuthService is co-hosted.
 
+# --- TLS / mTLS ---
 TLS_ENABLE=false
 MTLS_ENABLE=false
 TCP_TLS_ENABLE=false
+SERVER_NAME=
+# CLIENT_CA_CERT=./configs/tls-client/ca.crt
+# CLIENT_CERT=./configs/tls-client/tls.crt
+# CLIENT_KEY=./configs/tls-client/tls.key
+# SERVER_CA_CERT=./configs/tls-server/ca.crt
+# SERVER_CERT=./configs/tls-server/tls.crt
+# SERVER_KEY=./configs/tls-server/tls.key
+
+# --- CORS (required non-empty in prod when gateway is enabled; kit #224+) ---
 CORS_ALLOW_ORIGINS=*
 
+# --- NATS ---
 NATS_URL=nats://localhost:4222
-DATABASE_URL=mongodb://localhost:27017
-DB_NAME=__NAME__
-CACHE_URL=redis://localhost:6379
 
+# --- Mongo ---
+DATABASE_URL=mongodb://localhost:27017
+DATABASE_USER=
+DATABASE_PASSWORD=
+DB_NAME=__NAME__
+
+# --- Redis ---
+CACHE_URL=redis://localhost:6379
+CACHE_USER=
+CACHE_PASSWORD=
+
+# --- Server ports ---
 PORT=8081
 GAME_URL=localhost:8081
 # TCP/zinx is opt-in (TcpModule / AllWithTCPModule) and has NO gRPC auth.

--- a/.agents/skills/create-game/assets/template/cmd/__NAME__/service-thin/main.go.tmpl
+++ b/.agents/skills/create-game/assets/template/cmd/__NAME__/service-thin/main.go.tmpl
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"github.com/gstones/moke-kit/fxmain"
+	"github.com/gstones/moke-kit/mq/pkg/mfx"
+	"github.com/gstones/moke-kit/orm/pkg/ofx"
+
+	"__MODULE__/pkg/dfx"
+	"__MODULE__/pkg/modules"
+)
+
+// Thin-style entry: game transports only (no in-process platform services).
+// Scaffold default still uses dfx.AuthModule stub locally.
+// When wiring platform: replace dfx.AuthModule with auth.AuthMiddlewareModule,
+// set AUTH_URL to the remote AuthService, and add platform *ClientModule imports.
+// Do not keep stub + platform middleware (both provide AuthMiddleware).
+func main() {
+	fxmain.Main(
+		mfx.NatsModule,
+		mfx.LocalModule,
+		ofx.RedisCacheModule,
+
+		modules.AllModule,
+		dfx.AuthModule,
+	)
+}

--- a/.agents/skills/create-game/assets/template/pkg/modules/__NAME___module.go.tmpl
+++ b/.agents/skills/create-game/assets/template/pkg/modules/__NAME___module.go.tmpl
@@ -7,18 +7,18 @@ import (
 	"__MODULE__/pkg/dfx"
 )
 
-// GrpcModule starts the game gRPC service with AuthModule.
+// GrpcModule starts the game gRPC service only.
+// Auth is not included — pair dfx.AuthModule (or platform middleware) in main.
 var GrpcModule = fx.Module("grpcService",
 	dfx.SettingsModule,
-	dfx.AuthModule,
 	__NAME__.ServiceInstance,
 	__NAME__.GrpcService,
 )
 
-// HttpModule starts gRPC + grpc-gateway with AuthModule.
+// HttpModule starts gRPC + grpc-gateway.
+// Auth is not included — pair auth in main the same way as GrpcModule / AllModule.
 var HttpModule = fx.Module("httpService",
 	dfx.SettingsModule,
-	dfx.AuthModule,
 	__NAME__.ServiceInstance,
 	__NAME__.GrpcService,
 	__NAME__.HttpService,

--- a/.agents/skills/create-game/references/template-map.md
+++ b/.agents/skills/create-game/references/template-map.md
@@ -22,12 +22,13 @@ Templates live in `assets/template/`. Placeholders:
   .env.example                # AUTH/TLS/CORS/NATS/Mongo/Redis
   api/<name>/<name>.proto
   api/gen/...                 # from buf generate
-  cmd/<name>/service/main.go  # AllModule + dfx.AuthModule stub (TCP opt-in)
+  cmd/<name>/service/main.go       # AllModule + dfx.AuthModule stub (TCP opt-in)
+  cmd/<name>/service-thin/main.go  # game-only thin topology (swap stub for platform middleware)
   cmd/<name>/client/main.go
   internal/services/<name>/...  # no WithoutAuth; UID from auth context only
   internal/clients/<name>/...
   pkg/dfx/...                 # AuthModule stub (swap for platform in main; not both)
-  pkg/modules/<name>_module.go  # AllModule has no auth provider
+  pkg/modules/<name>_module.go  # Grpc/Http/All modules have no auth provider
   deployment/docker-compose/...
   build/package/docker/Dockerfile
   tests/<name>/<name>.js

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -14,7 +14,8 @@ reference platform and game repositories.
 `create-game` skill templates follow game secure defaults (`AllModule` + stub auth in
 `main`, no `WithoutAuth` on public services, gRPC+HTTP default, TCP opt-in, cancelable Watch).
 
-Consumers may still pin `go.mod` to `#224` while `#228` lands on `main`; bump when you need the StopServing deadline behavior or want CI parity.
+`create-game` also ships `service-thin` and keeps auth out of `GrpcModule` / `HttpModule` /
+`AllModule` (pair stub or platform middleware in `main` only).
 
 ## Tracking issues
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Continues [kit#223](https://github.com/GStones/moke-kit/issues/223) create-game alignment after #226 / #228.

### Changes
- Strip stub `AuthModule` from `GrpcModule` / `HttpModule` (pair auth in `main` only)
- Add `cmd/<name>/service-thin` template
- Expand `.env.example.tmpl` toward game AUTH/TLS/CORS settings
- Update template-map + COMPATIBILITY notes

### Test plan
- [x] Template/docs review
- [ ] CI green

Related: [platform#28](https://github.com/moke-game/platform/compare/main...cursor/issue-23-kit228-jwt-buf-3293), [game follow-up](https://github.com/moke-game/game/compare/main...cursor/issue-18-kit228-modules-3293)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-398a3149-3eb1-4944-b716-74b5ecd93293?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-398a3149-3eb1-4944-b716-74b5ecd93293&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

