### PR TITLE
fix(create-game): comment AUTH_URL defaults; refresh COMPATIBILITY

### DIFF
--- a/.agents/skills/create-game/assets/template/.env.example.tmpl
+++ b/.agents/skills/create-game/assets/template/.env.example.tmpl
@@ -7,15 +7,17 @@ DEPLOYMENT=local
 VERSION=0.0.1
 
 # --- Auth ---
-# Stub AuthModule (default main) requires a bearer and sets UIDContextKey from that token.
-# For real ValidateToken, swap dfx.AuthModule in main for platform
-# AuthMiddlewareModule / AuthAllModule (do not keep both) and set:
-AUTH_URL=localhost:8081
-AUTH_STORE_NAME=auth
-JWT_TOKEN_SECRET=change-me-in-prod
-JWT_TOKEN_EXPIRE=12
-# Thin topology: override AUTH_URL to the remote AuthService; never point it at
-# this process's PORT unless AuthService is co-hosted.
+# Stub AuthModule (default service/main) only needs a bearer token; it does not
+# dial AUTH_URL. Leave these commented until you swap dfx.AuthModule for platform
+# AuthMiddlewareModule / AuthAllModule (do not keep both).
+#
+# Aggregate (AuthAllModule co-hosted): AUTH_URL should match this process PORT.
+# Thin (AuthMiddlewareModule + remote AuthService): AUTH_URL must be the remote
+# auth host — never equal this process PORT unless AuthService is co-hosted.
+# AUTH_URL=localhost:8082
+# AUTH_STORE_NAME=auth
+# JWT_TOKEN_SECRET=change-me-in-prod
+# JWT_TOKEN_EXPIRE=12
 
 # --- TLS / mTLS ---
 TLS_ENABLE=false

--- a/.agents/skills/create-game/assets/template/cmd/__NAME__/service-thin/main.go.tmpl
+++ b/.agents/skills/create-game/assets/template/cmd/__NAME__/service-thin/main.go.tmpl
@@ -10,9 +10,10 @@ import (
 )
 
 // Thin-style entry: game transports only (no in-process platform services).
-// Scaffold default still uses dfx.AuthModule stub locally.
+// Scaffold default still uses dfx.AuthModule stub locally (no AUTH_URL dial).
 // When wiring platform: replace dfx.AuthModule with auth.AuthMiddlewareModule,
-// set AUTH_URL to the remote AuthService, and add platform *ClientModule imports.
+// set AUTH_URL to the *remote* AuthService (not this process PORT), and add
+// platform *ClientModule imports.
 // Do not keep stub + platform middleware (both provide AuthMiddleware).
 func main() {
 	fxmain.Main(

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -5,6 +5,7 @@ reference platform and game repositories.
 
 | moke-kit version | platform | game | Notes |
 | --- | --- | --- | --- |
+| `v1.0.5-0.20260812031519-a995d2ada33f` ([#229](https://github.com/GStones/moke-kit/pull/229)) | [platform#28](https://github.com/moke-game/platform/pull/28) | [game#24](https://github.com/moke-game/game/pull/24) | create-game thin/auth-free modules; platform kit#228 + prod JWT expire |
 | `v1.0.5-0.20260812022140-acb9f313d7fd` ([#228](https://github.com/GStones/moke-kit/pull/228)) | [platform#27](https://github.com/moke-game/platform/pull/27) | [game#22](https://github.com/moke-game/game/pull/22) | CAS/StopServing/MQ race tests + CI lint/vuln; platform jwt/v5 + CAS/chat lifecycle |
 | `v1.0.5-0.20260811094419-bcdfe55515cd` (#224) + create-game [#226](https://github.com/GStones/moke-kit/pull/226) | [platform#25](https://github.com/moke-game/platform/pull/25) | [game#20](https://github.com/moke-game/game/pull/20) | Binder fail-closed + scaffold auth defaults |
 | `v1.0.5-0.20260811094419-bcdfe55515cd` (#224) | [platform#24](https://github.com/moke-game/platform/pull/24) | [game#19](https://github.com/moke-game/game/pull/19) | Subscribe/CAS/CORS/TLS/Auth + binder fail-closed |
@@ -15,7 +16,8 @@ reference platform and game repositories.
 `main`, no `WithoutAuth` on public services, gRPC+HTTP default, TCP opt-in, cancelable Watch).
 
 `create-game` also ships `service-thin` and keeps auth out of `GrpcModule` / `HttpModule` /
-`AllModule` (pair stub or platform middleware in `main` only).
+`AllModule` (pair stub or platform middleware in `main` only). Stub auth does not dial
+`AUTH_URL`; leave platform auth env vars commented until you swap middleware.
 
 ## Tracking issues
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Post-merge follow-up after [#229](https://github.com/GStones/moke-kit/pull/229) / [platform#28](https://github.com/moke-game/platform/pull/28) / [game#24](https://github.com/moke-game/game/pull/24).

### Changes
- Comment out `AUTH_*` in `.env.example.tmpl` (stub auth does not dial `AUTH_URL`)
- Clarify aggregate vs thin `AUTH_URL` guidance; thin example uses remote `8082`
- Refresh COMPATIBILITY matrix for #229 / platform#28 / game#24

### Test plan
- [x] Docs/template only
- [ ] CI green
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-398a3149-3eb1-4944-b716-74b5ecd93293?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-398a3149-3eb1-4944-b716-74b5ecd93293&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

