### PR TITLE
fix(cache): HASH cache + async Mongo write-back (complete #215)

### DIFF
--- a/orm/nosql/cache/redis_cache.go
+++ b/orm/nosql/cache/redis_cache.go
@@ -2,61 +2,102 @@ package cache
 
 import (
 	"context"
-	"encoding/json"
 	"time"
 
 	"github.com/redis/go-redis/v9"
 	"go.uber.org/zap"
 
+	"github.com/gstones/moke-kit/orm/nosql/diface"
 	"github.com/gstones/moke-kit/orm/nosql/key"
 )
 
 var (
-	// ExpireRangeMin is the minimum expire time
+	// ExpireRangeMin is the minimum expire time used by callers for jittered TTLs.
 	ExpireRangeMin = 40 * time.Minute
-	// ExpireRangeMax is the maximum expire time
+	// ExpireRangeMax is the maximum expire time used by callers for jittered TTLs.
 	ExpireRangeMax = 60 * time.Minute
 )
 
-// RedisCache is a redis cache
+// RedisCache is a redis HASH cache.
 type RedisCache struct {
 	logger *zap.Logger
 	*redis.Client
 }
 
-// CreateRedisCache creates a redis cache
+var _ diface.ICache = (*RedisCache)(nil)
+
+// CreateRedisCache creates a redis cache.
 func CreateRedisCache(logger *zap.Logger, client *redis.Client) *RedisCache {
 	return &RedisCache{logger, client}
 }
 
-// GetCache gets cache
-func (c *RedisCache) GetCache(ctx context.Context, key key.Key, doc any) bool {
+// GetCache loads HASH fields. When fields is empty, all fields are returned.
+func (c *RedisCache) GetCache(ctx context.Context, key key.Key, fields ...string) map[string]any {
 	if c == nil || c.Client == nil {
-		return false
+		return nil
 	}
-	if res := c.Get(ctx, key.String()); res.Err() != nil {
-		return false
-	} else if data, err := res.Bytes(); err != nil {
-		return false
-	} else if err := json.Unmarshal(data, doc); err != nil {
-		return false
+
+	keyStr := key.String()
+	if len(fields) > 0 {
+		result, err := c.HMGet(ctx, keyStr, fields...).Result()
+		if err != nil {
+			c.logger.Error("get cache failed", zap.Error(err), zap.String("key", keyStr))
+			return nil
+		}
+		data := make(map[string]any, len(fields))
+		for i, field := range fields {
+			if result[i] != nil {
+				data[field] = result[i]
+			}
+		}
+		if len(data) == 0 {
+			return nil
+		}
+		return data
 	}
-	return true
+
+	allData, err := c.HGetAll(ctx, keyStr).Result()
+	if err != nil {
+		c.logger.Error("get cache failed", zap.Error(err), zap.String("key", keyStr))
+		return nil
+	}
+	if len(allData) == 0 {
+		return nil
+	}
+	res := make(map[string]any, len(allData))
+	for k, v := range allData {
+		if v != "" {
+			res[k] = v
+		}
+	}
+	return res
 }
 
-// SetCache sets cache
-func (c *RedisCache) SetCache(ctx context.Context, key key.Key, doc any, expire time.Duration) {
+// SetCache writes HASH fields with HSET and optional EXPIRE.
+func (c *RedisCache) SetCache(
+	ctx context.Context,
+	key key.Key,
+	data map[string]any,
+	expire time.Duration,
+) error {
 	if c == nil || c.Client == nil {
-		return
+		return nil
 	}
-	if data, err := json.Marshal(doc); err != nil {
-		return
-	} else if res := c.Set(ctx, key.String(), data, expire); res.Err() != nil {
-		return
+	if len(data) == 0 {
+		return nil
 	}
+	if res := c.HSet(ctx, key.String(), data); res.Err() != nil {
+		return res.Err()
+	}
+	if expire > 0 {
+		if res := c.Expire(ctx, key.String(), expire); res.Err() != nil {
+			return res.Err()
+		}
+	}
+	return nil
 }
 
-// DeleteCache deletes cache
+// DeleteCache deletes cache.
 func (c *RedisCache) DeleteCache(ctx context.Context, key key.Key) {
 	if c == nil || c.Client == nil {
 		return

--- a/orm/nosql/cache/redis_cache.go
+++ b/orm/nosql/cache/redis_cache.go
@@ -2,6 +2,7 @@ package cache
 
 import (
 	"context"
+	"strings"
 	"time"
 
 	"github.com/redis/go-redis/v9"
@@ -31,6 +32,19 @@ func CreateRedisCache(logger *zap.Logger, client *redis.Client) *RedisCache {
 	return &RedisCache{logger, client}
 }
 
+func isWrongType(err error) bool {
+	return err != nil && strings.Contains(err.Error(), "WRONGTYPE")
+}
+
+// clearLegacyKey deletes a pre-HASH string value that conflicts with HSET/HGETALL.
+func (c *RedisCache) clearLegacyKey(ctx context.Context, keyStr string, err error) {
+	if !isWrongType(err) {
+		return
+	}
+	c.logger.Warn("clearing legacy non-HASH cache key", zap.String("key", keyStr), zap.Error(err))
+	_ = c.Del(ctx, keyStr).Err()
+}
+
 // GetCache loads HASH fields. When fields is empty, all fields are returned.
 func (c *RedisCache) GetCache(ctx context.Context, key key.Key, fields ...string) map[string]any {
 	if c == nil || c.Client == nil {
@@ -41,7 +55,10 @@ func (c *RedisCache) GetCache(ctx context.Context, key key.Key, fields ...string
 	if len(fields) > 0 {
 		result, err := c.HMGet(ctx, keyStr, fields...).Result()
 		if err != nil {
-			c.logger.Error("get cache failed", zap.Error(err), zap.String("key", keyStr))
+			c.clearLegacyKey(ctx, keyStr, err)
+			if !isWrongType(err) {
+				c.logger.Error("get cache failed", zap.Error(err), zap.String("key", keyStr))
+			}
 			return nil
 		}
 		data := make(map[string]any, len(fields))
@@ -58,7 +75,10 @@ func (c *RedisCache) GetCache(ctx context.Context, key key.Key, fields ...string
 
 	allData, err := c.HGetAll(ctx, keyStr).Result()
 	if err != nil {
-		c.logger.Error("get cache failed", zap.Error(err), zap.String("key", keyStr))
+		c.clearLegacyKey(ctx, keyStr, err)
+		if !isWrongType(err) {
+			c.logger.Error("get cache failed", zap.Error(err), zap.String("key", keyStr))
+		}
 		return nil
 	}
 	if len(allData) == 0 {
@@ -86,11 +106,20 @@ func (c *RedisCache) SetCache(
 	if len(data) == 0 {
 		return nil
 	}
-	if res := c.HSet(ctx, key.String(), data); res.Err() != nil {
-		return res.Err()
+
+	keyStr := key.String()
+	if res := c.HSet(ctx, keyStr, data); res.Err() != nil {
+		if !isWrongType(res.Err()) {
+			return res.Err()
+		}
+		// Upgrade path: older versions stored a JSON string under the same key.
+		c.clearLegacyKey(ctx, keyStr, res.Err())
+		if retry := c.HSet(ctx, keyStr, data); retry.Err() != nil {
+			return retry.Err()
+		}
 	}
 	if expire > 0 {
-		if res := c.Expire(ctx, key.String(), expire); res.Err() != nil {
+		if res := c.Expire(ctx, keyStr, expire); res.Err() != nil {
 			return res.Err()
 		}
 	}

--- a/orm/nosql/cache/redis_cache_test.go
+++ b/orm/nosql/cache/redis_cache_test.go
@@ -2,6 +2,7 @@ package cache
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -23,4 +24,16 @@ func TestRedisCacheNilClientNoPanic(t *testing.T) {
 		t.Fatal(err)
 	}
 	c.DeleteCache(context.Background(), k)
+}
+
+func TestIsWrongType(t *testing.T) {
+	if !isWrongType(errors.New("WRONGTYPE Operation against a key holding the wrong kind of value")) {
+		t.Fatal("expected WRONGTYPE detection")
+	}
+	if isWrongType(errors.New("connection refused")) {
+		t.Fatal("did not expect WRONGTYPE detection")
+	}
+	if isWrongType(nil) {
+		t.Fatal("nil error should not be WRONGTYPE")
+	}
 }

--- a/orm/nosql/cache/redis_cache_test.go
+++ b/orm/nosql/cache/redis_cache_test.go
@@ -16,10 +16,11 @@ func TestRedisCacheNilClientNoPanic(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	var dst map[string]string
-	if c.GetCache(context.Background(), k, &dst) {
+	if got := c.GetCache(context.Background(), k); got != nil {
 		t.Fatal("expected cache miss")
 	}
-	c.SetCache(context.Background(), k, map[string]string{"x": "y"}, time.Minute)
+	if err := c.SetCache(context.Background(), k, map[string]any{"x": "y"}, time.Minute); err != nil {
+		t.Fatal(err)
+	}
 	c.DeleteCache(context.Background(), k)
 }

--- a/orm/nosql/common.go
+++ b/orm/nosql/common.go
@@ -13,6 +13,8 @@ import (
 const (
 	// cacheFieldVersion stores the document CAS version inside a HASH cache entry.
 	cacheFieldVersion = "__version"
+	// cacheFieldEpoch stores the document generation fence inside a HASH cache entry.
+	cacheFieldEpoch = "__epoch"
 	// cacheFieldData stores the JSON-encoded document payload inside a HASH cache entry.
 	cacheFieldData = "__data"
 )

--- a/orm/nosql/common.go
+++ b/orm/nosql/common.go
@@ -58,7 +58,33 @@ func marshalAnyMap(m map[string]any) (map[string]any, error) {
 	return res, nil
 }
 
+func structFieldIndex(v reflect.Value) map[string]reflect.Value {
+	t := v.Type()
+	index := make(map[string]reflect.Value, v.NumField()*2)
+	for i := 0; i < v.NumField(); i++ {
+		field := t.Field(i)
+		if !field.IsExported() {
+			continue
+		}
+		fv := v.Field(i)
+		if !fv.CanSet() {
+			continue
+		}
+		index[field.Name] = fv
+		jsonTag := field.Tag.Get("json")
+		if jsonTag == "" || jsonTag == "-" {
+			continue
+		}
+		name := strings.Split(jsonTag, ",")[0]
+		if name != "" {
+			index[name] = fv
+		}
+	}
+	return index
+}
+
 // map2StructShallow copies map values into exported struct fields.
+// Keys may be Go field names or json tag names produced by struct2MapShallow.
 func map2StructShallow(m map[string]any, obj any) error {
 	if obj == nil {
 		return nil
@@ -76,12 +102,14 @@ func map2StructShallow(m map[string]any, obj any) error {
 	if v.Kind() != reflect.Struct {
 		return fmt.Errorf("input obj is not a struct, but %T", obj)
 	}
+
+	fields := structFieldIndex(v)
 	for k1, v1 := range m {
 		if v1 == nil {
 			continue
 		}
-		field := v.FieldByName(k1)
-		if !field.IsValid() || !field.CanSet() {
+		field, ok := fields[k1]
+		if !ok {
 			continue
 		}
 		mv1 := reflect.ValueOf(v1)

--- a/orm/nosql/common.go
+++ b/orm/nosql/common.go
@@ -64,11 +64,11 @@ func map2StructShallow(m map[string]any, obj any) error {
 		return nil
 	}
 	v := reflect.ValueOf(obj)
-	for v.Kind() == reflect.Ptr {
+	for v.Kind() == reflect.Pointer {
 		if v.IsNil() {
 			return fmt.Errorf("input obj is a nil pointer")
 		}
-		if v.Elem().Kind() == reflect.Ptr && v.Elem().IsNil() {
+		if v.Elem().Kind() == reflect.Pointer && v.Elem().IsNil() {
 			v.Elem().Set(reflect.New(v.Elem().Type().Elem()))
 		}
 		v = v.Elem()
@@ -117,7 +117,7 @@ func struct2MapShallow(obj any) (map[string]any, error) {
 	}
 
 	v := reflect.ValueOf(obj)
-	for v.Kind() == reflect.Ptr {
+	for v.Kind() == reflect.Pointer {
 		if v.IsNil() {
 			return nil, fmt.Errorf("input obj is a nil pointer")
 		}

--- a/orm/nosql/common.go
+++ b/orm/nosql/common.go
@@ -92,11 +92,11 @@ func map2StructShallow(m map[string]any, obj any) error {
 		return nil
 	}
 	v := reflect.ValueOf(obj)
-	for v.Kind() == reflect.Pointer {
+	for v.Kind() == reflect.Ptr {
 		if v.IsNil() {
 			return fmt.Errorf("input obj is a nil pointer")
 		}
-		if v.Elem().Kind() == reflect.Pointer && v.Elem().IsNil() {
+		if v.Elem().Kind() == reflect.Ptr && v.Elem().IsNil() {
 			v.Elem().Set(reflect.New(v.Elem().Type().Elem()))
 		}
 		v = v.Elem()

--- a/orm/nosql/common.go
+++ b/orm/nosql/common.go
@@ -1,0 +1,218 @@
+package nosql
+
+import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"strconv"
+	"strings"
+
+	"github.com/gstones/moke-kit/orm/nosql/noptions"
+)
+
+const (
+	// cacheFieldVersion stores the document CAS version inside a HASH cache entry.
+	cacheFieldVersion = "__version"
+	// cacheFieldData stores the JSON-encoded document payload inside a HASH cache entry.
+	cacheFieldData = "__data"
+)
+
+// isBasicType checks whether reflect.Kind is a Go basic type.
+func isBasicType(k reflect.Kind) bool {
+	switch k {
+	case reflect.Bool,
+		reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,
+		reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr,
+		reflect.Float32, reflect.Float64,
+		reflect.Complex64, reflect.Complex128,
+		reflect.String:
+		return true
+	default:
+		return false
+	}
+}
+
+// marshalAnyMap converts non-basic map values to JSON for Redis HASH storage.
+func marshalAnyMap(m map[string]any) (map[string]any, error) {
+	if m == nil {
+		return make(map[string]any), nil
+	}
+
+	res := make(map[string]any, len(m))
+	for k, v := range m {
+		if v == nil {
+			res[k] = nil
+			continue
+		}
+		vType := reflect.TypeOf(v)
+		if isBasicType(vType.Kind()) {
+			res[k] = v
+			continue
+		}
+		js, err := json.Marshal(v)
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal: %w", err)
+		}
+		res[k] = js
+	}
+	return res, nil
+}
+
+// map2StructShallow copies map values into exported struct fields.
+func map2StructShallow(m map[string]any, obj any) error {
+	if obj == nil {
+		return nil
+	}
+	v := reflect.ValueOf(obj)
+	for v.Kind() == reflect.Ptr {
+		if v.IsNil() {
+			return fmt.Errorf("input obj is a nil pointer")
+		}
+		if v.Elem().Kind() == reflect.Ptr && v.Elem().IsNil() {
+			v.Elem().Set(reflect.New(v.Elem().Type().Elem()))
+		}
+		v = v.Elem()
+	}
+	if v.Kind() != reflect.Struct {
+		return fmt.Errorf("input obj is not a struct, but %T", obj)
+	}
+	for k1, v1 := range m {
+		if v1 == nil {
+			continue
+		}
+		field := v.FieldByName(k1)
+		if !field.IsValid() || !field.CanSet() {
+			continue
+		}
+		mv1 := reflect.ValueOf(v1)
+		if mv1.Type().ConvertibleTo(field.Type()) {
+			field.Set(mv1.Convert(field.Type()))
+			continue
+		}
+
+		var jsonData []byte
+		switch typed := v1.(type) {
+		case string:
+			jsonData = []byte(typed)
+		case []byte:
+			jsonData = typed
+		default:
+			var err error
+			jsonData, err = json.Marshal(v1)
+			if err != nil {
+				return fmt.Errorf("failed to marshal value for field %s: %w", k1, err)
+			}
+		}
+		if err := json.Unmarshal(jsonData, field.Addr().Interface()); err != nil {
+			return fmt.Errorf("failed to unmarshal field %s: %w", k1, err)
+		}
+	}
+	return nil
+}
+
+// struct2MapShallow converts exported top-level struct fields to map[string]any.
+func struct2MapShallow(obj any) (map[string]any, error) {
+	if obj == nil {
+		return nil, fmt.Errorf("input obj is nil")
+	}
+
+	v := reflect.ValueOf(obj)
+	for v.Kind() == reflect.Ptr {
+		if v.IsNil() {
+			return nil, fmt.Errorf("input obj is a nil pointer")
+		}
+		v = v.Elem()
+	}
+	if v.Kind() != reflect.Struct {
+		return nil, fmt.Errorf("input obj is not a struct, but %T", obj)
+	}
+
+	res := make(map[string]any, v.NumField())
+	t := v.Type()
+	for i := 0; i < v.NumField(); i++ {
+		field := t.Field(i)
+		jsonTag := field.Tag.Get("json")
+		bsonTag := field.Tag.Get("bson")
+		if jsonTag == "-" || bsonTag == "-" {
+			continue
+		}
+		if !field.IsExported() {
+			continue
+		}
+		fieldName := field.Name
+		if jsonTag != "" {
+			tagParts := strings.Split(jsonTag, ",")
+			if tagParts[0] != "" {
+				fieldName = tagParts[0]
+			}
+		}
+		res[fieldName] = v.Field(i).Interface()
+	}
+	return res, nil
+}
+
+// diffMapAny compares two maps and returns added/changed/deleted keys.
+func diffMapAny(oldMap, newMap map[string]any) (map[string]any, error) {
+	changes := make(map[string]any)
+	for key, newValue := range newMap {
+		if oldValue, exists := oldMap[key]; !exists {
+			changes[key] = newValue
+		} else if !reflect.DeepEqual(oldValue, newValue) {
+			changes[key] = newValue
+		}
+	}
+	for key := range oldMap {
+		if _, exists := newMap[key]; !exists {
+			changes[key] = nil
+		}
+	}
+	return changes, nil
+}
+
+func parseCacheVersion(v any) (noptions.Version, bool) {
+	switch typed := v.(type) {
+	case int64:
+		return typed, true
+	case int32:
+		return noptions.Version(typed), true
+	case int:
+		return noptions.Version(typed), true
+	case float64:
+		return noptions.Version(typed), true
+	case json.Number:
+		n, err := typed.Int64()
+		if err != nil {
+			return 0, false
+		}
+		return n, true
+	case string:
+		n, err := strconv.ParseInt(typed, 10, 64)
+		if err != nil {
+			return 0, false
+		}
+		return n, true
+	case []byte:
+		n, err := strconv.ParseInt(string(typed), 10, 64)
+		if err != nil {
+			return 0, false
+		}
+		return n, true
+	default:
+		return 0, false
+	}
+}
+
+func asJSONBytes(v any) ([]byte, error) {
+	switch typed := v.(type) {
+	case nil:
+		return nil, fmt.Errorf("nil json payload")
+	case []byte:
+		return typed, nil
+	case string:
+		return []byte(typed), nil
+	case json.RawMessage:
+		return typed, nil
+	default:
+		return json.Marshal(typed)
+	}
+}

--- a/orm/nosql/common_test.go
+++ b/orm/nosql/common_test.go
@@ -1,0 +1,154 @@
+package nosql
+
+import (
+	"encoding/json"
+	"errors"
+	"reflect"
+	"testing"
+)
+
+type helperSubData struct {
+	SubMessage string
+	SubList    []string
+}
+
+type helperTestData struct {
+	Message string
+	AList   []string
+	BMap    map[string]string
+	SubData *helperSubData
+}
+
+func TestMarshalAnyMap(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   map[string]any
+		want    map[string]any
+		wantErr error
+	}{
+		{
+			name: "basic types",
+			input: map[string]any{
+				"int":    42,
+				"string": "hello",
+				"bool":   true,
+			},
+			want: map[string]any{
+				"int":    42,
+				"string": "hello",
+				"bool":   true,
+			},
+		},
+		{
+			name: "nested struct",
+			input: map[string]any{
+				"struct": struct {
+					Name string
+					Age  int
+				}{
+					Name: "John",
+					Age:  30,
+				},
+			},
+			want: func() map[string]any {
+				js, _ := json.Marshal(struct {
+					Name string
+					Age  int
+				}{
+					Name: "John",
+					Age:  30,
+				})
+				return map[string]any{"struct": js}
+			}(),
+		},
+		{
+			name: "unsupported type",
+			input: map[string]any{
+				"channel": make(chan int),
+			},
+			wantErr: errors.New("failed to marshal: json: unsupported type: chan int"),
+		},
+		{
+			name:  "empty map",
+			input: map[string]any{},
+			want:  map[string]any{},
+		},
+		{
+			name:  "nil map",
+			input: nil,
+			want:  map[string]any{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := marshalAnyMap(tt.input)
+			if (err != nil) != (tt.wantErr != nil) {
+				t.Fatalf("got error = %v, want error = %v", err, tt.wantErr)
+			}
+			if err != nil && err.Error() != tt.wantErr.Error() {
+				t.Fatalf("got error = %v, want error = %v", err, tt.wantErr)
+			}
+			if err == nil && !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("got = %v, want = %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMap2StructShallow(t *testing.T) {
+	oldData := &helperTestData{
+		Message: "hello",
+		AList:   []string{"a", "b"},
+		BMap:    map[string]string{"key1": "value1", "key2": "value2"},
+		SubData: &helperSubData{
+			SubMessage: "sub hello",
+			SubList:    []string{"sub a", "sub b"},
+		},
+	}
+	oldMap, err := struct2MapShallow(oldData)
+	if err != nil {
+		t.Fatalf("Error converting old data to map: %v", err)
+	}
+	data, err := marshalAnyMap(oldMap)
+	if err != nil {
+		t.Fatalf("Error converting old data to map: %v", err)
+	}
+	newData := &helperTestData{}
+	if err := map2StructShallow(data, newData); err != nil {
+		t.Fatalf("map2StructShallow failed: %v", err)
+	}
+	if newData.Message != oldData.Message {
+		t.Fatalf("message=%q want %q", newData.Message, oldData.Message)
+	}
+}
+
+func TestStruct2MapShallowDiff(t *testing.T) {
+	oldData := &helperTestData{
+		Message: "hello",
+		AList:   []string{"a", "b"},
+		BMap:    map[string]string{"key1": "value1", "key2": "value2"},
+		SubData: &helperSubData{
+			SubMessage: "sub hello",
+			SubList:    []string{"sub a", "sub b"},
+		},
+	}
+	oldMap, err := struct2MapShallow(oldData)
+	if err != nil {
+		t.Fatalf("Error converting old data to map: %v", err)
+	}
+
+	oldData.AList = append(oldData.AList, "c")
+	newMap, err := struct2MapShallow(oldData)
+	if err != nil {
+		t.Fatalf("Error converting new data to map: %v", err)
+	}
+
+	changes, err := diffMapAny(oldMap, newMap)
+	if err != nil {
+		t.Fatalf("Error generating change set: %v", err)
+	}
+	if _, ok := changes["AList"]; !ok {
+		t.Fatalf("expected AList change, got %#v", changes)
+	}
+}

--- a/orm/nosql/common_test.go
+++ b/orm/nosql/common_test.go
@@ -123,6 +123,29 @@ func TestMap2StructShallow(t *testing.T) {
 	}
 }
 
+func TestMap2StructShallowJSONTags(t *testing.T) {
+	type tagged struct {
+		DisplayName string `json:"display_name"`
+		Count       int    `json:"count"`
+	}
+	src := &tagged{DisplayName: "alice", Count: 3}
+	m, err := struct2MapShallow(src)
+	if err != nil {
+		t.Fatalf("struct2MapShallow: %v", err)
+	}
+	if _, ok := m["display_name"]; !ok {
+		t.Fatalf("expected json tag key, got %#v", m)
+	}
+
+	dst := &tagged{}
+	if err := map2StructShallow(m, dst); err != nil {
+		t.Fatalf("map2StructShallow: %v", err)
+	}
+	if dst.DisplayName != "alice" || dst.Count != 3 {
+		t.Fatalf("round-trip mismatch: %#v", dst)
+	}
+}
+
 func TestStruct2MapShallowDiff(t *testing.T) {
 	oldData := &helperTestData{
 		Message: "hello",

--- a/orm/nosql/config.go
+++ b/orm/nosql/config.go
@@ -1,0 +1,74 @@
+package nosql
+
+import (
+	"errors"
+	"time"
+
+	"github.com/gstones/moke-kit/mq/miface"
+)
+
+// WriteBackConfig configures write-back workers.
+type WriteBackConfig struct {
+	// Enabled toggles write-back.
+	Enabled bool `json:"enabled" yaml:"enabled" envconfig:"WRITEBACK_ENABLED" default:"false"`
+	// Delay is the publish delay before write-back.
+	Delay time.Duration `json:"delay" yaml:"delay" envconfig:"WRITEBACK_DELAY" default:"500ms"`
+	// BatchSize is reserved for future batching.
+	BatchSize int `json:"batch_size" yaml:"batch_size" envconfig:"WRITEBACK_BATCH_SIZE" default:"100"`
+	// MaxRetries is reserved for future retry policy.
+	MaxRetries int `json:"max_retries" yaml:"max_retries" envconfig:"WRITEBACK_MAX_RETRIES" default:"3"`
+	// RetryDelay is reserved for future retry policy.
+	RetryDelay time.Duration `json:"retry_delay" yaml:"retry_delay" envconfig:"WRITEBACK_RETRY_DELAY" default:"1s"`
+	// WorkerCount is the number of write-back subscribers.
+	WorkerCount int `json:"worker_count" yaml:"worker_count" envconfig:"WRITEBACK_WORKER_COUNT" default:"1"`
+	// QueueSize is reserved for future buffering.
+	QueueSize int `json:"queue_size" yaml:"queue_size" envconfig:"WRITEBACK_QUEUE_SIZE" default:"1000"`
+}
+
+// Validate validates configuration.
+func (c WriteBackConfig) Validate() error {
+	if !c.Enabled {
+		return nil
+	}
+	if c.Delay < 0 {
+		return errors.New("WriteBack delay cannot be negative")
+	}
+	if c.BatchSize <= 0 {
+		return errors.New("WriteBack batch size must be positive")
+	}
+	if c.MaxRetries < 0 {
+		return errors.New("WriteBack max retries cannot be negative")
+	}
+	if c.RetryDelay < 0 {
+		return errors.New("WriteBack retry delay cannot be negative")
+	}
+	if c.WorkerCount <= 0 {
+		return errors.New("WriteBack worker count must be positive")
+	}
+	if c.QueueSize <= 0 {
+		return errors.New("WriteBack queue size must be positive")
+	}
+	return nil
+}
+
+// ToWriteBackOptions converts config into document write-back options.
+func (c WriteBackConfig) ToWriteBackOptions(mq miface.MessageQueue) WriteBackOptions {
+	return WriteBackOptions{
+		Enabled: c.Enabled,
+		Delay:   c.Delay,
+		MQ:      mq,
+	}
+}
+
+// DefaultWriteBackConfig returns the default write-back configuration.
+func DefaultWriteBackConfig() WriteBackConfig {
+	return WriteBackConfig{
+		Enabled:     false,
+		Delay:       DefaultWriteBackDelay,
+		BatchSize:   100,
+		MaxRetries:  3,
+		RetryDelay:  time.Second,
+		WorkerCount: 1,
+		QueueSize:   1000,
+	}
+}

--- a/orm/nosql/config_test.go
+++ b/orm/nosql/config_test.go
@@ -185,6 +185,23 @@ func TestWriteBackManager_EnabledRequiresCache(t *testing.T) {
 	assert.Error(t, manager.Start())
 }
 
+func TestWriteBackManager_StartIdempotent(t *testing.T) {
+	config := DefaultWriteBackConfig()
+	config.Enabled = true
+
+	manager, err := NewWriteBackManager(
+		config,
+		&capturingMQ{},
+		mock.NewMockDriverProvider(zap.NewNop()),
+		zap.NewNop(),
+		newMemoryHashCache(),
+	)
+	assert.NoError(t, err)
+	assert.NoError(t, manager.Start())
+	assert.Error(t, manager.Start())
+	assert.NoError(t, manager.Stop())
+}
+
 func TestWriteBackManager_IsHealthy(t *testing.T) {
 	config := DefaultWriteBackConfig()
 

--- a/orm/nosql/config_test.go
+++ b/orm/nosql/config_test.go
@@ -123,10 +123,12 @@ func TestNewWriteBackManager(t *testing.T) {
 		&capturingMQ{},
 		mock.NewMockDriverProvider(zap.NewNop()),
 		zap.NewNop(),
+		newMemoryHashCache(),
 	)
 	assert.NoError(t, err)
 	assert.NotNil(t, manager)
 	assert.Equal(t, config, manager.config)
+	assert.NotNil(t, manager.cache)
 }
 
 func TestNewWriteBackManager_InvalidConfig(t *testing.T) {
@@ -145,6 +147,7 @@ func TestNewWriteBackManager_InvalidConfig(t *testing.T) {
 		&capturingMQ{},
 		mock.NewMockDriverProvider(zap.NewNop()),
 		zap.NewNop(),
+		nil,
 	)
 	assert.Error(t, err)
 	assert.Nil(t, manager)
@@ -158,6 +161,7 @@ func TestWriteBackManager_DisabledStart(t *testing.T) {
 		&capturingMQ{},
 		mock.NewMockDriverProvider(zap.NewNop()),
 		zap.NewNop(),
+		nil,
 	)
 	assert.NoError(t, err)
 
@@ -174,6 +178,7 @@ func TestWriteBackManager_IsHealthy(t *testing.T) {
 		&capturingMQ{},
 		mock.NewMockDriverProvider(zap.NewNop()),
 		zap.NewNop(),
+		nil,
 	)
 	assert.NoError(t, err)
 	assert.True(t, manager.IsHealthy())

--- a/orm/nosql/config_test.go
+++ b/orm/nosql/config_test.go
@@ -1,0 +1,180 @@
+package nosql
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
+
+	"github.com/gstones/moke-kit/orm/nosql/mock"
+)
+
+func TestWriteBackConfig_Validate(t *testing.T) {
+	tests := []struct {
+		name    string
+		config  WriteBackConfig
+		wantErr bool
+	}{
+		{
+			name:    "valid disabled config",
+			config:  DefaultWriteBackConfig(),
+			wantErr: false,
+		},
+		{
+			name: "valid enabled config",
+			config: WriteBackConfig{
+				Enabled:     true,
+				Delay:       time.Second,
+				BatchSize:   100,
+				MaxRetries:  3,
+				RetryDelay:  time.Second,
+				WorkerCount: 2,
+				QueueSize:   1000,
+			},
+			wantErr: false,
+		},
+		{
+			name: "invalid: negative delay",
+			config: WriteBackConfig{
+				Enabled:     true,
+				Delay:       -time.Second,
+				BatchSize:   100,
+				MaxRetries:  3,
+				RetryDelay:  time.Second,
+				WorkerCount: 1,
+				QueueSize:   1000,
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid: zero batch size",
+			config: WriteBackConfig{
+				Enabled:     true,
+				Delay:       time.Second,
+				BatchSize:   0,
+				MaxRetries:  3,
+				RetryDelay:  time.Second,
+				WorkerCount: 1,
+				QueueSize:   1000,
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid: negative max retries",
+			config: WriteBackConfig{
+				Enabled:     true,
+				Delay:       time.Second,
+				BatchSize:   100,
+				MaxRetries:  -1,
+				RetryDelay:  time.Second,
+				WorkerCount: 1,
+				QueueSize:   1000,
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid: zero worker count",
+			config: WriteBackConfig{
+				Enabled:     true,
+				Delay:       time.Second,
+				BatchSize:   100,
+				MaxRetries:  3,
+				RetryDelay:  time.Second,
+				WorkerCount: 0,
+				QueueSize:   1000,
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.config.Validate()
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestWriteBackConfig_ToWriteBackOptions(t *testing.T) {
+	config := WriteBackConfig{
+		Enabled: true,
+		Delay:   time.Second,
+	}
+
+	mq := &capturingMQ{}
+	options := config.ToWriteBackOptions(mq)
+
+	assert.Equal(t, config.Enabled, options.Enabled)
+	assert.Equal(t, config.Delay, options.Delay)
+	assert.Equal(t, mq, options.MQ)
+}
+
+func TestNewWriteBackManager(t *testing.T) {
+	config := DefaultWriteBackConfig()
+	config.Enabled = true
+
+	manager, err := NewWriteBackManager(
+		config,
+		&capturingMQ{},
+		mock.NewMockDriverProvider(zap.NewNop()),
+		zap.NewNop(),
+	)
+	assert.NoError(t, err)
+	assert.NotNil(t, manager)
+	assert.Equal(t, config, manager.config)
+}
+
+func TestNewWriteBackManager_InvalidConfig(t *testing.T) {
+	config := WriteBackConfig{
+		Enabled:     true,
+		Delay:       -time.Second,
+		BatchSize:   100,
+		MaxRetries:  3,
+		RetryDelay:  time.Second,
+		WorkerCount: 1,
+		QueueSize:   1000,
+	}
+
+	manager, err := NewWriteBackManager(
+		config,
+		&capturingMQ{},
+		mock.NewMockDriverProvider(zap.NewNop()),
+		zap.NewNop(),
+	)
+	assert.Error(t, err)
+	assert.Nil(t, manager)
+}
+
+func TestWriteBackManager_DisabledStart(t *testing.T) {
+	config := DefaultWriteBackConfig()
+
+	manager, err := NewWriteBackManager(
+		config,
+		&capturingMQ{},
+		mock.NewMockDriverProvider(zap.NewNop()),
+		zap.NewNop(),
+	)
+	assert.NoError(t, err)
+
+	assert.NoError(t, manager.Start())
+	assert.Equal(t, 0, manager.GetMetrics().WorkerCount)
+	assert.NoError(t, manager.Stop())
+}
+
+func TestWriteBackManager_IsHealthy(t *testing.T) {
+	config := DefaultWriteBackConfig()
+
+	manager, err := NewWriteBackManager(
+		config,
+		&capturingMQ{},
+		mock.NewMockDriverProvider(zap.NewNop()),
+		zap.NewNop(),
+	)
+	assert.NoError(t, err)
+	assert.True(t, manager.IsHealthy())
+}

--- a/orm/nosql/config_test.go
+++ b/orm/nosql/config_test.go
@@ -170,6 +170,21 @@ func TestWriteBackManager_DisabledStart(t *testing.T) {
 	assert.NoError(t, manager.Stop())
 }
 
+func TestWriteBackManager_EnabledRequiresCache(t *testing.T) {
+	config := DefaultWriteBackConfig()
+	config.Enabled = true
+
+	manager, err := NewWriteBackManager(
+		config,
+		&capturingMQ{},
+		mock.NewMockDriverProvider(zap.NewNop()),
+		zap.NewNop(),
+		nil,
+	)
+	assert.NoError(t, err)
+	assert.Error(t, manager.Start())
+}
+
 func TestWriteBackManager_IsHealthy(t *testing.T) {
 	config := DefaultWriteBackConfig()
 

--- a/orm/nosql/diface/icache.go
+++ b/orm/nosql/diface/icache.go
@@ -7,28 +7,33 @@ import (
 	"github.com/gstones/moke-kit/orm/nosql/key"
 )
 
-// ICache provides a cache for Document objects.
+// ICache provides a HASH-oriented cache for Document objects.
+// Values are stored as Redis HASH field maps (or an equivalent in-memory map).
 type ICache interface {
-	// GetCache Get retrieves a Document from the cache.
-	GetCache(ctx context.Context, key key.Key, doc any) bool
-	// SetCache Set sets a Document in the cache.
-	SetCache(ctx context.Context, key key.Key, doc any, expire time.Duration)
-	// DeleteCache Delete deletes a Document from the cache.
+	// GetCache retrieves cache fields. When fields is empty, all fields are returned.
+	// A cache miss returns nil or an empty map.
+	GetCache(ctx context.Context, key key.Key, fields ...string) map[string]any
+	// SetCache writes cache fields and optionally sets an expiration.
+	SetCache(ctx context.Context, key key.Key, data map[string]any, expire time.Duration) error
+	// DeleteCache deletes a Document from the cache.
 	DeleteCache(ctx context.Context, key key.Key)
 }
-type defaultDocumentCache struct {
-}
 
-// DefaultDocumentCache returns a new ICache.
+type defaultDocumentCache struct{}
+
+var _ ICache = (*defaultDocumentCache)(nil)
+
+// DefaultDocumentCache returns a new no-op ICache.
 func DefaultDocumentCache() ICache {
 	return &defaultDocumentCache{}
 }
 
-func (c *defaultDocumentCache) GetCache(ctx context.Context, key key.Key, doc any) bool {
-	return false
+func (c *defaultDocumentCache) GetCache(ctx context.Context, key key.Key, fields ...string) map[string]any {
+	return nil
 }
 
-func (c *defaultDocumentCache) SetCache(ctx context.Context, key key.Key, doc any, expire time.Duration) {
+func (c *defaultDocumentCache) SetCache(ctx context.Context, key key.Key, data map[string]any, expire time.Duration) error {
+	return nil
 }
 
 func (c *defaultDocumentCache) DeleteCache(ctx context.Context, key key.Key) {

--- a/orm/nosql/document.go
+++ b/orm/nosql/document.go
@@ -19,8 +19,6 @@ import (
 const (
 	// MaxRetries is the maximum number of retries for update operations.
 	MaxRetries = 5
-	// DefaultCacheTTL is the default cache TTL for read-through caching.
-	DefaultCacheTTL = 30 * time.Minute
 	// DefaultWriteBackDelay is the default async write-back delay.
 	DefaultWriteBackDelay = 500 * time.Millisecond
 	// ExpireRangeMin is the minimum jittered cache expiration.
@@ -33,10 +31,13 @@ const (
 
 // WriteBackPayload is the delayed write-back message payload.
 type WriteBackPayload struct {
-	CollectionName string           `json:"collection"`
-	Key            string           `json:"key"`
-	Data           json.RawMessage  `json:"data"`
-	Version        noptions.Version `json:"version"`
+	CollectionName string          `json:"collection"`
+	Key            string          `json:"key"`
+	Data           json.RawMessage `json:"data"`
+	// Version is the optimistic target version after SaveAsync (not the CAS base).
+	Version noptions.Version `json:"version"`
+	// Epoch fences delete/recreate generations when workers can read cache.
+	Epoch int64 `json:"epoch"`
 }
 
 // WriteBackOptions configures delayed write-back behavior.
@@ -73,6 +74,7 @@ type DocumentBase struct {
 	clear   func()
 	data    any
 	version noptions.Version
+	epoch   int64
 
 	DocumentStore diface.ICollection
 	cache         diface.ICache
@@ -145,10 +147,15 @@ func (d *DocumentBase) cacheEnvelope() (map[string]any, error) {
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to marshal document for cache")
 	}
-	return map[string]any{
+	envelope := map[string]any{
 		cacheFieldVersion: d.version,
 		cacheFieldData:    string(raw),
-	}, nil
+	}
+	// Omit zero epochs so Load-from-DB after restart does not fence in-flight write-backs.
+	if d.epoch != 0 {
+		envelope[cacheFieldEpoch] = d.epoch
+	}
+	return envelope, nil
 }
 
 func (d *DocumentBase) updateCache() error {
@@ -172,6 +179,11 @@ func (d *DocumentBase) loadFromCache(m map[string]any) error {
 		return errors.Wrap(err, "failed to unmarshal cached document")
 	}
 	d.version = ver
+	if ep, ok := parseCacheVersion(m[cacheFieldEpoch]); ok {
+		d.epoch = ep
+	} else {
+		d.epoch = 0
+	}
 	return nil
 }
 
@@ -181,6 +193,7 @@ func scheduleWriteBack(
 	keyStr string,
 	raw json.RawMessage,
 	version noptions.Version,
+	epoch int64,
 ) error {
 	if mq == nil {
 		return errors.New("MQ client is nil")
@@ -190,6 +203,7 @@ func scheduleWriteBack(
 		Key:            keyStr,
 		Data:           raw,
 		Version:        version,
+		Epoch:          epoch,
 	}
 	return mq.Publish(WriteBackTopic, miface.WithJSON(payload))
 }
@@ -224,17 +238,24 @@ func applyWriteBackSnapshot(
 }
 
 // Create data and version in the database.
+// Each Create bumps epoch so delayed write-backs from a prior delete/recreate generation can be fenced.
 func (d *DocumentBase) Create() error {
+	d.epoch++
 	version, err := d.DocumentStore.Set(
 		d.ctx,
 		d.Key,
 		noptions.WithSource(d.data),
 	)
 	if err != nil {
+		d.epoch--
 		return err
 	}
 	d.version = version
-	return d.updateCache()
+	if err := d.updateCache(); err != nil {
+		d.epoch--
+		return err
+	}
+	return nil
 }
 
 // Load implements Read-Through caching through Redis HASH fields.
@@ -309,12 +330,13 @@ func (d *DocumentBase) SaveAsync() error {
 	collectionName := store.GetName()
 	keyStr := docKey.String()
 	delay := d.writeBack.Delay
+	epoch := d.epoch
 	go func() {
 		if delay > 0 {
 			time.Sleep(delay)
 		}
 		// Version is the optimistic target version (next), not the CAS base.
-		if err := scheduleWriteBack(mq, collectionName, keyStr, raw, next); err != nil {
+		if err := scheduleWriteBack(mq, collectionName, keyStr, raw, next, epoch); err != nil {
 			// Publish failed: best-effort sync fallback so data is not stuck in cache only.
 			// Use a fresh timeout context; the request ctx is usually already cancelled.
 			var src any

--- a/orm/nosql/document.go
+++ b/orm/nosql/document.go
@@ -300,9 +300,14 @@ func (d *DocumentBase) Load() error {
 		return err
 	}
 	d.version = version
-	// DB has no persisted epoch; clear any prior HASH generation before rewrite.
+	// DB has no persisted epoch. Preserve any existing cache fence so a concurrent
+	// Create/SaveAsync generation is not wiped by this read-through rewrite.
 	d.epoch = 0
-	d.cache.DeleteCache(d.ctx, d.Key)
+	if cached := d.cache.GetCache(d.ctx, d.Key, cacheFieldEpoch); len(cached) > 0 {
+		if ep, ok := parseCacheVersion(cached[cacheFieldEpoch]); ok {
+			d.epoch = ep
+		}
+	}
 	return d.updateCache()
 }
 

--- a/orm/nosql/document.go
+++ b/orm/nosql/document.go
@@ -2,12 +2,14 @@ package nosql
 
 import (
 	"context"
+	"encoding/json"
 	"math"
 	"math/rand"
 	"time"
 
 	"github.com/pkg/errors"
 
+	"github.com/gstones/moke-kit/mq/miface"
 	"github.com/gstones/moke-kit/orm/nerrors"
 	"github.com/gstones/moke-kit/orm/nosql/diface"
 	"github.com/gstones/moke-kit/orm/nosql/key"
@@ -15,13 +17,56 @@ import (
 )
 
 const (
-	// MaxRetries is the maximum number of retries for update operations
+	// MaxRetries is the maximum number of retries for update operations.
 	MaxRetries = 5
-	// DefaultCacheTTL is the default cache TTL for read-through caching
+	// DefaultCacheTTL is the default cache TTL for read-through caching.
 	DefaultCacheTTL = 30 * time.Minute
+	// DefaultWriteBackDelay is the default async write-back delay.
+	DefaultWriteBackDelay = 500 * time.Millisecond
+	// ExpireRangeMin is the minimum jittered cache expiration.
+	ExpireRangeMin = 6 * time.Hour
+	// ExpireRangeMax is the maximum jittered cache expiration.
+	ExpireRangeMax = 12 * time.Hour
+	// WriteBackTopic is the MQ topic used for delayed Mongo write-back.
+	WriteBackTopic = "nats://writeback"
 )
 
-// DocumentBase represents a base document structure for NoSQL operations
+// WriteBackPayload is the delayed write-back message payload.
+type WriteBackPayload struct {
+	CollectionName string           `json:"collection"`
+	Key            string           `json:"key"`
+	Data           json.RawMessage  `json:"data"`
+	Version        noptions.Version `json:"version"`
+}
+
+// WriteBackOptions configures delayed write-back behavior.
+type WriteBackOptions struct {
+	Enabled bool
+	Delay   time.Duration
+	MQ      miface.MessageQueue
+}
+
+// DefaultWriteBackOptions returns disabled write-back options.
+func DefaultWriteBackOptions() WriteBackOptions {
+	return WriteBackOptions{
+		Enabled: false,
+		Delay:   DefaultWriteBackDelay,
+		MQ:      nil,
+	}
+}
+
+// Validate validates write-back options.
+func (opts WriteBackOptions) Validate() error {
+	if opts.Enabled && opts.MQ == nil {
+		return errors.New("MQ client is required when WriteBack is enabled")
+	}
+	if opts.Delay < 0 {
+		return errors.New("WriteBack delay cannot be negative")
+	}
+	return nil
+}
+
+// DocumentBase represents a base document structure for NoSQL operations.
 type DocumentBase struct {
 	Key key.Key
 
@@ -32,6 +77,8 @@ type DocumentBase struct {
 	DocumentStore diface.ICollection
 	cache         diface.ICache
 	ctx           context.Context
+
+	writeBack WriteBackOptions
 }
 
 // Init performs an in-place initialization of a DocumentBase.
@@ -61,6 +108,26 @@ func (d *DocumentBase) InitWithCache(
 	d.DocumentStore = store
 	d.Key = key
 	d.cache = cache
+	d.writeBack = DefaultWriteBackOptions()
+}
+
+// EnableWriteBackWithMQ enables delayed MQ write-back.
+func (d *DocumentBase) EnableWriteBackWithMQ(mqClient miface.MessageQueue, delay time.Duration) error {
+	if mqClient == nil {
+		return errors.New("MQ client cannot be nil")
+	}
+	d.writeBack.Enabled = true
+	d.writeBack.MQ = mqClient
+	if delay > 0 {
+		d.writeBack.Delay = delay
+	}
+	return d.writeBack.Validate()
+}
+
+// DisableWriteBack disables delayed write-back.
+func (d *DocumentBase) DisableWriteBack() {
+	d.writeBack.Enabled = false
+	d.writeBack.MQ = nil
 }
 
 // Clear clears all data on this DocumentBase.
@@ -69,7 +136,56 @@ func (d *DocumentBase) Clear() {
 	d.clear()
 }
 
-// Create  data and version in the database.
+func randomExpiration() time.Duration {
+	return ExpireRangeMin + time.Duration(rand.Int63n(int64(ExpireRangeMax-ExpireRangeMin)))
+}
+
+func (d *DocumentBase) cacheEnvelope() (map[string]any, error) {
+	raw, err := json.Marshal(d.data)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to marshal document for cache")
+	}
+	return map[string]any{
+		cacheFieldVersion: d.version,
+		cacheFieldData:    string(raw),
+	}, nil
+}
+
+func (d *DocumentBase) updateCache() error {
+	envelope, err := d.cacheEnvelope()
+	if err != nil {
+		return err
+	}
+	return d.cache.SetCache(d.ctx, d.Key, envelope, randomExpiration())
+}
+
+func (d *DocumentBase) loadFromCache(m map[string]any) error {
+	ver, ok := parseCacheVersion(m[cacheFieldVersion])
+	if !ok {
+		return errors.New("cache entry missing version")
+	}
+	raw, err := asJSONBytes(m[cacheFieldData])
+	if err != nil {
+		return errors.Wrap(err, "cache entry missing data")
+	}
+	if err := json.Unmarshal(raw, d.data); err != nil {
+		return errors.Wrap(err, "failed to unmarshal cached document")
+	}
+	d.version = ver
+	return nil
+}
+
+func (d *DocumentBase) scheduleWriteBack(raw json.RawMessage, version noptions.Version) error {
+	payload := &WriteBackPayload{
+		CollectionName: d.DocumentStore.GetName(),
+		Key:            d.Key.String(),
+		Data:           raw,
+		Version:        version,
+	}
+	return d.writeBack.MQ.Publish(WriteBackTopic, miface.WithJSON(payload))
+}
+
+// Create data and version in the database.
 func (d *DocumentBase) Create() error {
 	version, err := d.DocumentStore.Set(
 		d.ctx,
@@ -80,29 +196,22 @@ func (d *DocumentBase) Create() error {
 		return err
 	}
 	d.version = version
-	return nil
+	return d.updateCache()
 }
 
-// VersionCache is a cache of a version and its data structure.
-type VersionCache struct {
-	Version any
-	Data    any
-}
-
-// Load implements Read-Through caching
+// Load implements Read-Through caching through Redis HASH fields.
 func (d *DocumentBase) Load() error {
 	d.clear()
-	cache := &VersionCache{
-		Version: &d.version,
-		Data:    d.data,
+
+	if cached := d.cache.GetCache(d.ctx, d.Key); len(cached) > 0 {
+		if err := d.loadFromCache(cached); err == nil {
+			return nil
+		}
+		// Corrupt/incomplete cache entries fall through to the database.
+		d.cache.DeleteCache(d.ctx, d.Key)
+		d.clear()
 	}
 
-	// Try cache first
-	if d.cache.GetCache(d.ctx, d.Key, cache) {
-		return nil
-	}
-
-	// Cache miss - load from database
 	version, err := d.DocumentStore.Get(
 		d.ctx,
 		d.Key,
@@ -111,20 +220,12 @@ func (d *DocumentBase) Load() error {
 	if err != nil {
 		return err
 	}
-
 	d.version = version
-	// Update cache after loading from database
-	d.cache.SetCache(d.ctx, d.Key, &VersionCache{
-		Version: d.version,
-		Data:    d.data,
-	}, DefaultCacheTTL)
-
-	return nil
+	return d.updateCache()
 }
 
-// Save implements synchronous write with cache update
+// Save implements synchronous write with HASH cache update.
 func (d *DocumentBase) Save() error {
-	// 直接同步写入数据库
 	version, err := d.DocumentStore.Set(
 		d.ctx,
 		d.Key,
@@ -135,13 +236,39 @@ func (d *DocumentBase) Save() error {
 		return err
 	}
 	d.version = version
+	return d.updateCache()
+}
 
-	// 更新缓存
-	d.cache.SetCache(d.ctx, d.Key, &VersionCache{
-		Version: d.version,
-		Data:    d.data,
-	}, DefaultCacheTTL)
+// SaveAsync optimistically updates the HASH cache and schedules a delayed DB write-back.
+// The DB CAS uses the previous version; the cache stores previous+1.
+func (d *DocumentBase) SaveAsync() error {
+	if d.version == noptions.NoVersion {
+		return errors.New("cannot async-save a document without a version")
+	}
 
+	raw, err := json.Marshal(d.data)
+	if err != nil {
+		return errors.Wrap(err, "failed to marshal document for async save")
+	}
+
+	prev := d.version
+	d.version = prev + 1
+	if err := d.updateCache(); err != nil {
+		d.version = prev
+		return err
+	}
+
+	if !(d.writeBack.Enabled && d.writeBack.MQ != nil) {
+		return nil
+	}
+
+	delay := d.writeBack.Delay
+	go func() {
+		if delay > 0 {
+			time.Sleep(delay)
+		}
+		_ = d.scheduleWriteBack(raw, prev)
+	}()
 	return nil
 }
 
@@ -156,13 +283,12 @@ func (d *DocumentBase) doUpdate(f func() bool, u func() error) error {
 			return nil
 		} else {
 			lastErr = err
-			// Exponential backoff with jitter
 			backoff := time.Duration(math.Pow(2, float64(r))) * time.Millisecond
 			jitter := time.Duration(rand.Float64() * float64(backoff))
 			time.Sleep(backoff + jitter)
 
 			if err := d.Load(); err != nil {
-				return err
+				return errors.Wrap(err, "failed to reload during update retry")
 			}
 		}
 	}
@@ -172,20 +298,22 @@ func (d *DocumentBase) doUpdate(f func() bool, u func() error) error {
 	return errors.Wrap(nerrors.ErrTooManyRetries, "no underlying error")
 }
 
-// Update change the data with the given function and CAS(compare and swap) save it to the database.
-// If the function returns false, the update will be aborted.
-// If the update CAS fails, the function will be retried up to MaxRetries times with a randomized backoff.
+// Update changes data with CAS save and retries.
 func (d *DocumentBase) Update(f func() bool) error {
-	if err := d.doUpdate(f, func() error {
+	return d.doUpdate(f, func() error {
 		return d.Save()
-	}); err != nil {
-		return err
-	} else {
-		return nil
-	}
+	})
 }
 
-// Delete delete data from the database.
+// UpdateAsync mutates in-memory data, updates HASH cache, and schedules write-back.
+func (d *DocumentBase) UpdateAsync(f func() bool) error {
+	if !f() {
+		return nerrors.ErrUpdateLogicFailed
+	}
+	return d.SaveAsync()
+}
+
+// Delete deletes data from the database and cache.
 func (d *DocumentBase) Delete() error {
 	if err := d.DocumentStore.Delete(d.ctx, d.Key); err != nil {
 		return err

--- a/orm/nosql/document.go
+++ b/orm/nosql/document.go
@@ -175,14 +175,23 @@ func (d *DocumentBase) loadFromCache(m map[string]any) error {
 	return nil
 }
 
-func (d *DocumentBase) scheduleWriteBack(raw json.RawMessage, version noptions.Version) error {
+func scheduleWriteBack(
+	mq miface.MessageQueue,
+	collectionName string,
+	keyStr string,
+	raw json.RawMessage,
+	version noptions.Version,
+) error {
+	if mq == nil {
+		return errors.New("MQ client is nil")
+	}
 	payload := &WriteBackPayload{
-		CollectionName: d.DocumentStore.GetName(),
-		Key:            d.Key.String(),
+		CollectionName: collectionName,
+		Key:            keyStr,
 		Data:           raw,
 		Version:        version,
 	}
-	return d.writeBack.MQ.Publish(WriteBackTopic, miface.WithJSON(payload))
+	return mq.Publish(WriteBackTopic, miface.WithJSON(payload))
 }
 
 // Create data and version in the database.
@@ -241,9 +250,14 @@ func (d *DocumentBase) Save() error {
 
 // SaveAsync optimistically updates the HASH cache and schedules a delayed DB write-back.
 // The DB CAS uses the previous version; the cache stores previous+1.
+// When write-back is disabled, SaveAsync falls back to synchronous Save().
 func (d *DocumentBase) SaveAsync() error {
 	if d.version == noptions.NoVersion {
 		return errors.New("cannot async-save a document without a version")
+	}
+
+	if !d.writeBack.Enabled || d.writeBack.MQ == nil {
+		return d.Save()
 	}
 
 	raw, err := json.Marshal(d.data)
@@ -258,16 +272,16 @@ func (d *DocumentBase) SaveAsync() error {
 		return err
 	}
 
-	if !d.writeBack.Enabled || d.writeBack.MQ == nil {
-		return nil
-	}
-
+	// Capture publish dependencies so DisableWriteBack cannot nil-deref the goroutine.
+	mq := d.writeBack.MQ
+	collectionName := d.DocumentStore.GetName()
+	keyStr := d.Key.String()
 	delay := d.writeBack.Delay
 	go func() {
 		if delay > 0 {
 			time.Sleep(delay)
 		}
-		_ = d.scheduleWriteBack(raw, prev)
+		_ = scheduleWriteBack(mq, collectionName, keyStr, raw, prev)
 	}()
 	return nil
 }

--- a/orm/nosql/document.go
+++ b/orm/nosql/document.go
@@ -238,21 +238,26 @@ func applyWriteBackSnapshot(
 }
 
 // Create data and version in the database.
-// Each Create bumps epoch so delayed write-backs from a prior delete/recreate generation can be fenced.
+// Each Create assigns a unique epoch so delayed write-backs from a prior
+// delete/recreate generation can be fenced across DocumentBase instances.
 func (d *DocumentBase) Create() error {
-	d.epoch++
+	prevEpoch := d.epoch
+	d.epoch = time.Now().UnixNano()
+	if d.epoch == prevEpoch {
+		d.epoch++
+	}
 	version, err := d.DocumentStore.Set(
 		d.ctx,
 		d.Key,
 		noptions.WithSource(d.data),
 	)
 	if err != nil {
-		d.epoch--
+		d.epoch = prevEpoch
 		return err
 	}
 	d.version = version
 	if err := d.updateCache(); err != nil {
-		d.epoch--
+		d.epoch = prevEpoch
 		return err
 	}
 	return nil
@@ -326,6 +331,7 @@ func (d *DocumentBase) SaveAsync() error {
 	// Capture publish dependencies so DisableWriteBack cannot nil-deref the goroutine.
 	mq := d.writeBack.MQ
 	store := d.DocumentStore
+	cache := d.cache
 	docKey := d.Key
 	collectionName := store.GetName()
 	keyStr := docKey.String()
@@ -345,6 +351,9 @@ func (d *DocumentBase) SaveAsync() error {
 			}
 			fbCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 			defer cancel()
+			if cacheEpochMismatch(fbCtx, cache, docKey, epoch) {
+				return
+			}
 			_ = applyWriteBackSnapshot(fbCtx, store, docKey, src, next)
 		}
 	}()

--- a/orm/nosql/document.go
+++ b/orm/nosql/document.go
@@ -194,6 +194,53 @@ func scheduleWriteBack(
 	return mq.Publish(WriteBackTopic, miface.WithJSON(payload))
 }
 
+var (
+	errWriteBackStale        = errors.New("write-back snapshot is stale")
+	errWriteBackAmbiguousGap = errors.New("write-back version gap is ambiguous")
+)
+
+// applyWriteBackSnapshot CAS-writes src at expected, rebasing at most one version ahead.
+// Larger gaps are rejected so delete/recreate cannot be overwritten by in-flight old messages.
+func applyWriteBackSnapshot(
+	ctx context.Context,
+	coll diface.ICollection,
+	docKey key.Key,
+	src any,
+	expected noptions.Version,
+) error {
+	_, err := coll.Set(
+		ctx,
+		docKey,
+		noptions.WithSource(src),
+		noptions.WithVersion(expected),
+	)
+	if err == nil {
+		return nil
+	}
+	if !isVersionMismatch(err) {
+		return err
+	}
+
+	var discard any
+	current, gerr := coll.Get(ctx, docKey, noptions.WithDestination(&discard))
+	if gerr != nil {
+		return gerr
+	}
+	if expected < current {
+		return errWriteBackStale
+	}
+	if expected > current+1 {
+		return errWriteBackAmbiguousGap
+	}
+	_, err = coll.Set(
+		ctx,
+		docKey,
+		noptions.WithSource(src),
+		noptions.WithVersion(current),
+	)
+	return err
+}
+
 // Create data and version in the database.
 func (d *DocumentBase) Create() error {
 	version, err := d.DocumentStore.Set(
@@ -276,7 +323,6 @@ func (d *DocumentBase) SaveAsync() error {
 	mq := d.writeBack.MQ
 	store := d.DocumentStore
 	docKey := d.Key
-	ctx := d.ctx
 	collectionName := store.GetName()
 	keyStr := docKey.String()
 	delay := d.writeBack.Delay
@@ -286,16 +332,14 @@ func (d *DocumentBase) SaveAsync() error {
 		}
 		if err := scheduleWriteBack(mq, collectionName, keyStr, raw, prev); err != nil {
 			// Publish failed: best-effort sync fallback so data is not stuck in cache only.
+			// Use a fresh timeout context; the request ctx is usually already cancelled.
 			var src any
 			if json.Unmarshal(raw, &src) != nil {
 				return
 			}
-			_, _ = store.Set(
-				ctx,
-				docKey,
-				noptions.WithSource(src),
-				noptions.WithVersion(prev),
-			)
+			fbCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
+			_ = applyWriteBackSnapshot(fbCtx, store, docKey, src, prev)
 		}
 	}()
 	return nil

--- a/orm/nosql/document.go
+++ b/orm/nosql/document.go
@@ -110,6 +110,8 @@ func (d *DocumentBase) InitWithCache(
 	d.DocumentStore = store
 	d.Key = key
 	d.cache = cache
+	d.version = noptions.NoVersion
+	d.epoch = 0
 	d.writeBack = DefaultWriteBackOptions()
 }
 
@@ -135,6 +137,7 @@ func (d *DocumentBase) DisableWriteBack() {
 // Clear clears all data on this DocumentBase.
 func (d *DocumentBase) Clear() {
 	d.version = noptions.NoVersion
+	d.epoch = 0
 	d.clear()
 }
 
@@ -210,8 +213,9 @@ func scheduleWriteBack(
 
 var errWriteBackStale = errors.New("write-back snapshot is stale")
 
-// applyWriteBackSnapshot installs src when targetVersion is newer than the DB version.
-// payload.Version is the optimistic target version (cache version after SaveAsync).
+// applyWriteBackSnapshot installs src and advances the DB CAS version up to targetVersion.
+// Store Set only $inc version by 1, so a gapped target (e.g. 5 while DB is 1) is
+// fast-forwarded with the same payload until DB version == targetVersion.
 // Older/equal targets are dropped so out-of-order delayed messages cannot clobber newer data.
 func applyWriteBackSnapshot(
 	ctx context.Context,
@@ -220,21 +224,32 @@ func applyWriteBackSnapshot(
 	src any,
 	targetVersion noptions.Version,
 ) error {
-	var discard any
-	current, err := coll.Get(ctx, docKey, noptions.WithDestination(&discard))
-	if err != nil {
-		return err
+	for {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		var discard any
+		current, err := coll.Get(ctx, docKey, noptions.WithDestination(&discard))
+		if err != nil {
+			return err
+		}
+		if targetVersion <= current {
+			return errWriteBackStale
+		}
+		newVer, err := coll.Set(
+			ctx,
+			docKey,
+			noptions.WithSource(src),
+			noptions.WithVersion(current),
+		)
+		if err != nil {
+			return err
+		}
+		if newVer >= targetVersion {
+			return nil
+		}
+		// Version advanced but still behind the optimistic target; keep fast-forwarding.
 	}
-	if targetVersion <= current {
-		return errWriteBackStale
-	}
-	_, err = coll.Set(
-		ctx,
-		docKey,
-		noptions.WithSource(src),
-		noptions.WithVersion(current),
-	)
-	return err
 }
 
 // Create data and version in the database.
@@ -285,6 +300,9 @@ func (d *DocumentBase) Load() error {
 		return err
 	}
 	d.version = version
+	// DB has no persisted epoch; clear any prior HASH generation before rewrite.
+	d.epoch = 0
+	d.cache.DeleteCache(d.ctx, d.Key)
 	return d.updateCache()
 }
 

--- a/orm/nosql/document.go
+++ b/orm/nosql/document.go
@@ -258,7 +258,7 @@ func (d *DocumentBase) SaveAsync() error {
 		return err
 	}
 
-	if !(d.writeBack.Enabled && d.writeBack.MQ != nil) {
+	if !d.writeBack.Enabled || d.writeBack.MQ == nil {
 		return nil
 	}
 

--- a/orm/nosql/document.go
+++ b/orm/nosql/document.go
@@ -274,14 +274,29 @@ func (d *DocumentBase) SaveAsync() error {
 
 	// Capture publish dependencies so DisableWriteBack cannot nil-deref the goroutine.
 	mq := d.writeBack.MQ
-	collectionName := d.DocumentStore.GetName()
-	keyStr := d.Key.String()
+	store := d.DocumentStore
+	docKey := d.Key
+	ctx := d.ctx
+	collectionName := store.GetName()
+	keyStr := docKey.String()
 	delay := d.writeBack.Delay
 	go func() {
 		if delay > 0 {
 			time.Sleep(delay)
 		}
-		_ = scheduleWriteBack(mq, collectionName, keyStr, raw, prev)
+		if err := scheduleWriteBack(mq, collectionName, keyStr, raw, prev); err != nil {
+			// Publish failed: best-effort sync fallback so data is not stuck in cache only.
+			var src any
+			if json.Unmarshal(raw, &src) != nil {
+				return
+			}
+			_, _ = store.Set(
+				ctx,
+				docKey,
+				noptions.WithSource(src),
+				noptions.WithVersion(prev),
+			)
+		}
 	}()
 	return nil
 }

--- a/orm/nosql/document.go
+++ b/orm/nosql/document.go
@@ -247,13 +247,12 @@ func applyWriteBackSnapshot(
 		if err != nil {
 			return err
 		}
-		if targetVersion <= current {
-			if hasExpect && current >= targetVersion {
-				return nil
-			}
+		// An unexpected CAS jump means another writer advanced the chain; do not
+		// treat overshoot as a successful apply of this snapshot.
+		if hasExpect && current != expectCurrent {
 			return errWriteBackStale
 		}
-		if hasExpect && current != expectCurrent {
+		if targetVersion <= current {
 			return errWriteBackStale
 		}
 		newVer, err := coll.Set(

--- a/orm/nosql/document.go
+++ b/orm/nosql/document.go
@@ -194,43 +194,25 @@ func scheduleWriteBack(
 	return mq.Publish(WriteBackTopic, miface.WithJSON(payload))
 }
 
-var (
-	errWriteBackStale        = errors.New("write-back snapshot is stale")
-	errWriteBackAmbiguousGap = errors.New("write-back version gap is ambiguous")
-)
+var errWriteBackStale = errors.New("write-back snapshot is stale")
 
-// applyWriteBackSnapshot CAS-writes src at expected, rebasing at most one version ahead.
-// Larger gaps are rejected so delete/recreate cannot be overwritten by in-flight old messages.
+// applyWriteBackSnapshot installs src when targetVersion is newer than the DB version.
+// payload.Version is the optimistic target version (cache version after SaveAsync).
+// Older/equal targets are dropped so out-of-order delayed messages cannot clobber newer data.
 func applyWriteBackSnapshot(
 	ctx context.Context,
 	coll diface.ICollection,
 	docKey key.Key,
 	src any,
-	expected noptions.Version,
+	targetVersion noptions.Version,
 ) error {
-	_, err := coll.Set(
-		ctx,
-		docKey,
-		noptions.WithSource(src),
-		noptions.WithVersion(expected),
-	)
-	if err == nil {
-		return nil
-	}
-	if !isVersionMismatch(err) {
+	var discard any
+	current, err := coll.Get(ctx, docKey, noptions.WithDestination(&discard))
+	if err != nil {
 		return err
 	}
-
-	var discard any
-	current, gerr := coll.Get(ctx, docKey, noptions.WithDestination(&discard))
-	if gerr != nil {
-		return gerr
-	}
-	if expected < current {
+	if targetVersion <= current {
 		return errWriteBackStale
-	}
-	if expected > current+1 {
-		return errWriteBackAmbiguousGap
 	}
 	_, err = coll.Set(
 		ctx,
@@ -296,7 +278,7 @@ func (d *DocumentBase) Save() error {
 }
 
 // SaveAsync optimistically updates the HASH cache and schedules a delayed DB write-back.
-// The DB CAS uses the previous version; the cache stores previous+1.
+// The write-back payload carries the optimistic target version (previous+1).
 // When write-back is disabled, SaveAsync falls back to synchronous Save().
 func (d *DocumentBase) SaveAsync() error {
 	if d.version == noptions.NoVersion {
@@ -313,7 +295,8 @@ func (d *DocumentBase) SaveAsync() error {
 	}
 
 	prev := d.version
-	d.version = prev + 1
+	next := prev + 1
+	d.version = next
 	if err := d.updateCache(); err != nil {
 		d.version = prev
 		return err
@@ -330,7 +313,8 @@ func (d *DocumentBase) SaveAsync() error {
 		if delay > 0 {
 			time.Sleep(delay)
 		}
-		if err := scheduleWriteBack(mq, collectionName, keyStr, raw, prev); err != nil {
+		// Version is the optimistic target version (next), not the CAS base.
+		if err := scheduleWriteBack(mq, collectionName, keyStr, raw, next); err != nil {
 			// Publish failed: best-effort sync fallback so data is not stuck in cache only.
 			// Use a fresh timeout context; the request ctx is usually already cancelled.
 			var src any
@@ -339,7 +323,7 @@ func (d *DocumentBase) SaveAsync() error {
 			}
 			fbCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 			defer cancel()
-			_ = applyWriteBackSnapshot(fbCtx, store, docKey, src, prev)
+			_ = applyWriteBackSnapshot(fbCtx, store, docKey, src, next)
 		}
 	}()
 	return nil

--- a/orm/nosql/document.go
+++ b/orm/nosql/document.go
@@ -154,11 +154,14 @@ func (d *DocumentBase) cacheEnvelope() (map[string]any, error) {
 		cacheFieldVersion: d.version,
 		cacheFieldData:    string(raw),
 	}
-	// Omit zero epochs so Load-from-DB after restart does not fence in-flight write-backs.
 	if d.epoch != 0 {
 		envelope[cacheFieldEpoch] = d.epoch
 	}
 	return envelope, nil
+}
+
+func newDocumentEpoch() int64 {
+	return time.Now().UnixNano()
 }
 
 func (d *DocumentBase) updateCache() error {
@@ -211,22 +214,33 @@ func scheduleWriteBack(
 	return mq.Publish(WriteBackTopic, miface.WithJSON(payload))
 }
 
-var errWriteBackStale = errors.New("write-back snapshot is stale")
+var (
+	errWriteBackStale = errors.New("write-back snapshot is stale")
+	errWriteBackEpoch = errors.New("write-back epoch mismatch")
+)
 
 // applyWriteBackSnapshot installs src and advances the DB CAS version up to targetVersion.
 // Store Set only $inc version by 1, so a gapped target (e.g. 5 while DB is 1) is
 // fast-forwarded with the same payload until DB version == targetVersion.
-// Older/equal targets are dropped so out-of-order delayed messages cannot clobber newer data.
+// Epoch is re-checked every iteration, and an unexpected version jump aborts so a
+// concurrent non-write-back writer is not overwritten across the remaining gap.
 func applyWriteBackSnapshot(
 	ctx context.Context,
 	coll diface.ICollection,
 	docKey key.Key,
 	src any,
 	targetVersion noptions.Version,
+	cache diface.ICache,
+	epoch int64,
 ) error {
+	var expectCurrent noptions.Version
+	hasExpect := false
 	for {
 		if err := ctx.Err(); err != nil {
 			return err
+		}
+		if cacheEpochMismatch(ctx, cache, docKey, epoch) {
+			return errWriteBackEpoch
 		}
 		var discard any
 		current, err := coll.Get(ctx, docKey, noptions.WithDestination(&discard))
@@ -234,6 +248,12 @@ func applyWriteBackSnapshot(
 			return err
 		}
 		if targetVersion <= current {
+			if hasExpect && current >= targetVersion {
+				return nil
+			}
+			return errWriteBackStale
+		}
+		if hasExpect && current != expectCurrent {
 			return errWriteBackStale
 		}
 		newVer, err := coll.Set(
@@ -245,10 +265,11 @@ func applyWriteBackSnapshot(
 		if err != nil {
 			return err
 		}
+		expectCurrent = newVer
+		hasExpect = true
 		if newVer >= targetVersion {
 			return nil
 		}
-		// Version advanced but still behind the optimistic target; keep fast-forwarding.
 	}
 }
 
@@ -257,7 +278,7 @@ func applyWriteBackSnapshot(
 // delete/recreate generation can be fenced across DocumentBase instances.
 func (d *DocumentBase) Create() error {
 	prevEpoch := d.epoch
-	d.epoch = time.Now().UnixNano()
+	d.epoch = newDocumentEpoch()
 	if d.epoch == prevEpoch {
 		d.epoch++
 	}
@@ -287,6 +308,8 @@ func (d *DocumentBase) Load() error {
 			return nil
 		}
 		// Corrupt/incomplete cache entries fall through to the database.
+		// Delete after the failed decode; a concurrent Create/SaveAsync may rewrite
+		// a fresh epoch before we reconstruct below.
 		d.cache.DeleteCache(d.ctx, d.Key)
 		d.clear()
 	}
@@ -300,13 +323,16 @@ func (d *DocumentBase) Load() error {
 		return err
 	}
 	d.version = version
-	// DB has no persisted epoch. Preserve any existing cache fence so a concurrent
-	// Create/SaveAsync generation is not wiped by this read-through rewrite.
+	// Preserve a concurrent generation fence when present; otherwise mint a new
+	// epoch so in-flight write-backs from a lost optimistic cache lineage are fenced.
 	d.epoch = 0
 	if cached := d.cache.GetCache(d.ctx, d.Key, cacheFieldEpoch); len(cached) > 0 {
 		if ep, ok := parseCacheVersion(cached[cacheFieldEpoch]); ok {
 			d.epoch = ep
 		}
+	}
+	if d.epoch == 0 {
+		d.epoch = newDocumentEpoch()
 	}
 	return d.updateCache()
 }
@@ -374,10 +400,7 @@ func (d *DocumentBase) SaveAsync() error {
 			}
 			fbCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 			defer cancel()
-			if cacheEpochMismatch(fbCtx, cache, docKey, epoch) {
-				return
-			}
-			_ = applyWriteBackSnapshot(fbCtx, store, docKey, src, next)
+			_ = applyWriteBackSnapshot(fbCtx, store, docKey, src, next, cache, epoch)
 		}
 	}()
 	return nil

--- a/orm/nosql/document_test.go
+++ b/orm/nosql/document_test.go
@@ -310,13 +310,14 @@ func TestDocumentBase_UpdateAsyncWriteBack(t *testing.T) {
 
 	cache := newMemoryHashCache()
 	mq := &capturingMQ{}
-	worker := NewWriteBackWorker(mq, provider, logger)
+	worker := NewWriteBackWorker(mq, provider, logger).WithCache(cache)
 	require.NoError(t, worker.Start())
 	defer worker.Stop()
 
 	td := &testDoc{ID: "wb-1", Data: &docPayload{Message: "hello"}}
 	td.InitWithCache(context.Background(), &td.Data, func() { td.Data = nil }, coll, k, cache)
 	require.NoError(t, td.Create())
+	require.Equal(t, int64(1), td.epoch)
 	require.NoError(t, td.EnableWriteBackWithMQ(mq, time.Millisecond))
 
 	require.NoError(t, td.UpdateAsync(func() bool {
@@ -334,6 +335,50 @@ func TestDocumentBase_UpdateAsyncWriteBack(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "async", retrieved.Message)
 	require.Equal(t, noptions.Version(2), ver)
+}
+
+func TestDocumentBase_DeleteRecreateFencesOldWriteBack(t *testing.T) {
+	t.Parallel()
+
+	logger := zaptest.NewLogger(t)
+	provider := mock.NewMockDriverProvider(logger)
+	coll, err := provider.OpenDbDriver("doc-epoch-fence")
+	require.NoError(t, err)
+
+	k, err := key.NewKeyFromParts("demo", "epoch-fence-1")
+	require.NoError(t, err)
+
+	cache := newMemoryHashCache()
+	mq := &capturingMQ{}
+	worker := NewWriteBackWorker(mq, provider, logger).WithCache(cache)
+	require.NoError(t, worker.Start())
+	defer worker.Stop()
+
+	td := &testDoc{ID: "epoch-fence-1", Data: &docPayload{Message: "gen1"}}
+	td.InitWithCache(context.Background(), &td.Data, func() { td.Data = nil }, coll, k, cache)
+	require.NoError(t, td.Create())
+	require.NoError(t, td.EnableWriteBackWithMQ(mq, 80*time.Millisecond))
+
+	require.NoError(t, td.UpdateAsync(func() bool {
+		td.Data.Message = "stale-gen1"
+		return true
+	}))
+
+	// Recreate under a new epoch before the delayed write-back lands.
+	require.NoError(t, td.Delete())
+	td.Data = &docPayload{Message: "gen2"}
+	require.NoError(t, td.Create())
+	require.Equal(t, int64(2), td.epoch)
+
+	require.Eventually(t, func() bool {
+		return worker.GetMetrics().FailedCount >= 1
+	}, 2*time.Second, 20*time.Millisecond)
+
+	var got docPayload
+	_, err = coll.Get(context.Background(), k, noptions.WithDestination(&got))
+	require.NoError(t, err)
+	require.Equal(t, "gen2", got.Message)
+	require.Equal(t, int64(0), worker.GetMetrics().ProcessedCount)
 }
 
 func TestDocumentBase_ConcurrentUpdates(t *testing.T) {

--- a/orm/nosql/document_test.go
+++ b/orm/nosql/document_test.go
@@ -11,13 +11,15 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zaptest"
 
+	"github.com/gstones/moke-kit/mq/miface"
+	"github.com/gstones/moke-kit/orm/nosql/diface"
 	"github.com/gstones/moke-kit/orm/nosql/key"
 	"github.com/gstones/moke-kit/orm/nosql/mock"
 	"github.com/gstones/moke-kit/orm/nosql/noptions"
 )
 
 type docPayload struct {
-	Message string `bson:"message"`
+	Message string `json:"message" bson:"message"`
 }
 
 type testDoc struct {
@@ -25,6 +27,107 @@ type testDoc struct {
 	ID   string
 	Data *docPayload
 }
+
+type memoryHashCache struct {
+	mu   sync.Mutex
+	data map[string]map[string]any
+}
+
+func newMemoryHashCache() *memoryHashCache {
+	return &memoryHashCache{data: make(map[string]map[string]any)}
+}
+
+func (c *memoryHashCache) GetCache(ctx context.Context, k key.Key, fields ...string) map[string]any {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	src, ok := c.data[k.String()]
+	if !ok {
+		return nil
+	}
+	if len(fields) == 0 {
+		out := make(map[string]any, len(src))
+		for key, val := range src {
+			out[key] = val
+		}
+		return out
+	}
+	out := make(map[string]any, len(fields))
+	for _, field := range fields {
+		if val, ok := src[field]; ok {
+			out[field] = val
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+func (c *memoryHashCache) SetCache(ctx context.Context, k key.Key, data map[string]any, expire time.Duration) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	dst := make(map[string]any, len(data))
+	for key, val := range data {
+		dst[key] = val
+	}
+	c.data[k.String()] = dst
+	return nil
+}
+
+func (c *memoryHashCache) DeleteCache(ctx context.Context, k key.Key) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	delete(c.data, k.String())
+}
+
+type capturingMQ struct {
+	mu       sync.Mutex
+	messages [][]byte
+	handler  miface.SubResponseHandler
+}
+
+func (m *capturingMQ) Publish(topic string, opts ...miface.PubOption) error {
+	options, err := miface.NewPubOptions(opts...)
+	if err != nil {
+		return err
+	}
+	m.mu.Lock()
+	m.messages = append(m.messages, append([]byte(nil), options.Data...))
+	handler := m.handler
+	m.mu.Unlock()
+	if handler != nil {
+		_ = handler(&staticMessage{data: options.Data}, nil)
+	}
+	return nil
+}
+
+func (m *capturingMQ) Subscribe(ctx context.Context, topic string, handler miface.SubResponseHandler, opts ...miface.SubOption) (miface.Subscription, error) {
+	m.mu.Lock()
+	m.handler = handler
+	m.mu.Unlock()
+	return &noopSub{}, nil
+}
+
+type staticMessage struct {
+	data []byte
+}
+
+func (m *staticMessage) Topic() string { return WriteBackTopic }
+func (m *staticMessage) Data() []byte  { return m.data }
+func (m *staticMessage) ID() string    { return "1" }
+func (m *staticMessage) VPtr() any     { return nil }
+
+type noopSub struct{}
+
+func (s *noopSub) IsValid() bool      { return true }
+func (s *noopSub) Unsubscribe() error { return nil }
+
+var (
+	_ diface.ICache       = (*memoryHashCache)(nil)
+	_ miface.MessageQueue = (*capturingMQ)(nil)
+	_ miface.Message      = (*staticMessage)(nil)
+	_ miface.Subscription = (*noopSub)(nil)
+)
 
 func TestDocumentBase_CRUD(t *testing.T) {
 	t.Parallel()
@@ -61,6 +164,71 @@ func TestDocumentBase_CRUD(t *testing.T) {
 	require.NoError(t, loaded.Delete())
 }
 
+func TestDocumentBase_HashCacheReadThrough(t *testing.T) {
+	t.Parallel()
+
+	logger := zaptest.NewLogger(t)
+	provider := mock.NewMockDriverProvider(logger)
+	coll, err := provider.OpenDbDriver("doc-cache")
+	require.NoError(t, err)
+
+	k, err := key.NewKeyFromParts("demo", "cache-1")
+	require.NoError(t, err)
+
+	cache := newMemoryHashCache()
+	td := &testDoc{ID: "cache-1", Data: &docPayload{Message: "cached"}}
+	td.InitWithCache(context.Background(), &td.Data, func() { td.Data = nil }, coll, k, cache)
+	require.NoError(t, td.Create())
+
+	// Delete underlying DB document; Load should still succeed from HASH cache.
+	require.NoError(t, coll.Delete(context.Background(), k))
+
+	loaded := &testDoc{ID: "cache-1", Data: &docPayload{}}
+	loaded.InitWithCache(context.Background(), &loaded.Data, func() { loaded.Data = nil }, coll, k, cache)
+	require.NoError(t, loaded.Load())
+	require.Equal(t, "cached", loaded.Data.Message)
+	require.Equal(t, noptions.Version(1), loaded.version)
+}
+
+func TestDocumentBase_UpdateAsyncWriteBack(t *testing.T) {
+	t.Parallel()
+
+	logger := zaptest.NewLogger(t)
+	provider := mock.NewMockDriverProvider(logger)
+	coll, err := provider.OpenDbDriver("doc-writeback")
+	require.NoError(t, err)
+
+	k, err := key.NewKeyFromParts("demo", "wb-1")
+	require.NoError(t, err)
+
+	cache := newMemoryHashCache()
+	mq := &capturingMQ{}
+	worker := NewWriteBackWorker(mq, provider, logger)
+	require.NoError(t, worker.Start())
+	defer worker.Stop()
+
+	td := &testDoc{ID: "wb-1", Data: &docPayload{Message: "hello"}}
+	td.InitWithCache(context.Background(), &td.Data, func() { td.Data = nil }, coll, k, cache)
+	require.NoError(t, td.Create())
+	require.NoError(t, td.EnableWriteBackWithMQ(mq, time.Millisecond))
+
+	require.NoError(t, td.UpdateAsync(func() bool {
+		td.Data.Message = "async"
+		return true
+	}))
+	require.Equal(t, noptions.Version(2), td.version)
+
+	require.Eventually(t, func() bool {
+		return worker.GetMetrics().ProcessedCount >= 1
+	}, 2*time.Second, 20*time.Millisecond)
+
+	var retrieved docPayload
+	ver, err := coll.Get(context.Background(), k, noptions.WithDestination(&retrieved))
+	require.NoError(t, err)
+	require.Equal(t, "async", retrieved.Message)
+	require.Equal(t, noptions.Version(2), ver)
+}
+
 func TestDocumentBase_ConcurrentUpdates(t *testing.T) {
 	t.Parallel()
 
@@ -76,9 +244,6 @@ func TestDocumentBase_ConcurrentUpdates(t *testing.T) {
 	seed.Init(context.Background(), &seed.Data, func() { seed.Data = nil }, coll, k)
 	require.NoError(t, seed.Create())
 
-	// Workers may contend past a single DocumentBase.Update's MaxRetries (5).
-	// Each worker reloads and retries until success so the test asserts CAS
-	// progress without flaking under -race stampede.
 	const workers = 10
 	const outerAttempts = 32
 

--- a/orm/nosql/document_test.go
+++ b/orm/nosql/document_test.go
@@ -383,6 +383,57 @@ func TestDocumentBase_DeleteRecreateFencesOldWriteBack(t *testing.T) {
 	require.Equal(t, int64(0), worker.GetMetrics().ProcessedCount)
 }
 
+func TestDocumentBase_ColdLoadMintsEpochAndFencesWriteBack(t *testing.T) {
+	t.Parallel()
+
+	logger := zaptest.NewLogger(t)
+	provider := mock.NewMockDriverProvider(logger)
+	coll, err := provider.OpenDbDriver("doc-cold-load-epoch")
+	require.NoError(t, err)
+
+	k, err := key.NewKeyFromParts("demo", "cold-1")
+	require.NoError(t, err)
+
+	cache := newMemoryHashCache()
+	mq := &capturingMQ{}
+	worker := NewWriteBackWorker(mq, provider, logger).WithCache(cache)
+	require.NoError(t, worker.Start())
+	defer worker.Stop()
+
+	td := &testDoc{ID: "cold-1", Data: &docPayload{Message: "gen1"}}
+	td.InitWithCache(context.Background(), &td.Data, func() { td.Data = nil }, coll, k, cache)
+	require.NoError(t, td.Create())
+	oldEpoch := td.epoch
+	require.NoError(t, td.EnableWriteBackWithMQ(mq, 60*time.Millisecond))
+
+	require.NoError(t, td.UpdateAsync(func() bool {
+		td.Data.Message = "stale-async"
+		return true
+	}))
+
+	// Simulate cache TTL loss, then read-through reconstructs with a new epoch.
+	cache.DeleteCache(context.Background(), k)
+	loaded := &testDoc{ID: "cold-1", Data: &docPayload{}}
+	loaded.InitWithCache(context.Background(), &loaded.Data, func() { loaded.Data = nil }, coll, k, cache)
+	require.NoError(t, loaded.Load())
+	require.NotZero(t, loaded.epoch)
+	require.NotEqual(t, oldEpoch, loaded.epoch)
+	require.NoError(t, loaded.Update(func() bool {
+		loaded.Data.Message = "sync-after-reload"
+		return true
+	}))
+
+	require.Eventually(t, func() bool {
+		return worker.GetMetrics().FailedCount >= 1
+	}, 2*time.Second, 20*time.Millisecond)
+
+	var got docPayload
+	_, err = coll.Get(context.Background(), k, noptions.WithDestination(&got))
+	require.NoError(t, err)
+	require.Equal(t, "sync-after-reload", got.Message)
+	require.Equal(t, int64(0), worker.GetMetrics().ProcessedCount)
+}
+
 func TestDocumentBase_SaveAsyncPublishFailureRespectsEpoch(t *testing.T) {
 	t.Parallel()
 

--- a/orm/nosql/document_test.go
+++ b/orm/nosql/document_test.go
@@ -2,6 +2,7 @@ package nosql
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 	"sync/atomic"
@@ -215,6 +216,54 @@ func TestDocumentBase_SaveAsyncWithoutWriteBackPersists(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "persisted", retrieved.Message)
 	require.Equal(t, noptions.Version(2), ver)
+}
+
+type failPublishMQ struct {
+	handler miface.SubResponseHandler
+}
+
+func (m *failPublishMQ) Publish(topic string, opts ...miface.PubOption) error {
+	return errors.New("publish failed")
+}
+
+func (m *failPublishMQ) Subscribe(
+	ctx context.Context,
+	topic string,
+	handler miface.SubResponseHandler,
+	opts ...miface.SubOption,
+) (miface.Subscription, error) {
+	m.handler = handler
+	return &noopSub{}, nil
+}
+
+func TestDocumentBase_SaveAsyncPublishFailureFallsBack(t *testing.T) {
+	t.Parallel()
+
+	logger := zaptest.NewLogger(t)
+	provider := mock.NewMockDriverProvider(logger)
+	coll, err := provider.OpenDbDriver("doc-publish-fail")
+	require.NoError(t, err)
+
+	k, err := key.NewKeyFromParts("demo", "pub-fail-1")
+	require.NoError(t, err)
+
+	cache := newMemoryHashCache()
+	mq := &failPublishMQ{}
+	td := &testDoc{ID: "pub-fail-1", Data: &docPayload{Message: "hello"}}
+	td.InitWithCache(context.Background(), &td.Data, func() { td.Data = nil }, coll, k, cache)
+	require.NoError(t, td.Create())
+	require.NoError(t, td.EnableWriteBackWithMQ(mq, time.Millisecond))
+
+	require.NoError(t, td.UpdateAsync(func() bool {
+		td.Data.Message = "fallback"
+		return true
+	}))
+
+	require.Eventually(t, func() bool {
+		var got docPayload
+		_, err := coll.Get(context.Background(), k, noptions.WithDestination(&got))
+		return err == nil && got.Message == "fallback"
+	}, time.Second, 10*time.Millisecond)
 }
 
 func TestDocumentBase_SaveAsyncDisableWriteBackNoPanic(t *testing.T) {

--- a/orm/nosql/document_test.go
+++ b/orm/nosql/document_test.go
@@ -190,6 +190,64 @@ func TestDocumentBase_HashCacheReadThrough(t *testing.T) {
 	require.Equal(t, noptions.Version(1), loaded.version)
 }
 
+func TestDocumentBase_SaveAsyncWithoutWriteBackPersists(t *testing.T) {
+	t.Parallel()
+
+	logger := zaptest.NewLogger(t)
+	provider := mock.NewMockDriverProvider(logger)
+	coll, err := provider.OpenDbDriver("doc-sync-fallback")
+	require.NoError(t, err)
+
+	k, err := key.NewKeyFromParts("demo", "sync-1")
+	require.NoError(t, err)
+
+	td := &testDoc{ID: "sync-1", Data: &docPayload{Message: "hello"}}
+	td.Init(context.Background(), &td.Data, func() { td.Data = nil }, coll, k)
+	require.NoError(t, td.Create())
+
+	require.NoError(t, td.UpdateAsync(func() bool {
+		td.Data.Message = "persisted"
+		return true
+	}))
+
+	var retrieved docPayload
+	ver, err := coll.Get(context.Background(), k, noptions.WithDestination(&retrieved))
+	require.NoError(t, err)
+	require.Equal(t, "persisted", retrieved.Message)
+	require.Equal(t, noptions.Version(2), ver)
+}
+
+func TestDocumentBase_SaveAsyncDisableWriteBackNoPanic(t *testing.T) {
+	t.Parallel()
+
+	logger := zaptest.NewLogger(t)
+	provider := mock.NewMockDriverProvider(logger)
+	coll, err := provider.OpenDbDriver("doc-disable-wb")
+	require.NoError(t, err)
+
+	k, err := key.NewKeyFromParts("demo", "disable-1")
+	require.NoError(t, err)
+
+	cache := newMemoryHashCache()
+	mq := &capturingMQ{}
+	td := &testDoc{ID: "disable-1", Data: &docPayload{Message: "hello"}}
+	td.InitWithCache(context.Background(), &td.Data, func() { td.Data = nil }, coll, k, cache)
+	require.NoError(t, td.Create())
+	require.NoError(t, td.EnableWriteBackWithMQ(mq, 30*time.Millisecond))
+
+	require.NoError(t, td.UpdateAsync(func() bool {
+		td.Data.Message = "async"
+		return true
+	}))
+	td.DisableWriteBack()
+
+	require.Eventually(t, func() bool {
+		mq.mu.Lock()
+		defer mq.mu.Unlock()
+		return len(mq.messages) >= 1
+	}, time.Second, 10*time.Millisecond)
+}
+
 func TestDocumentBase_UpdateAsyncWriteBack(t *testing.T) {
 	t.Parallel()
 

--- a/orm/nosql/document_test.go
+++ b/orm/nosql/document_test.go
@@ -317,7 +317,7 @@ func TestDocumentBase_UpdateAsyncWriteBack(t *testing.T) {
 	td := &testDoc{ID: "wb-1", Data: &docPayload{Message: "hello"}}
 	td.InitWithCache(context.Background(), &td.Data, func() { td.Data = nil }, coll, k, cache)
 	require.NoError(t, td.Create())
-	require.Equal(t, int64(1), td.epoch)
+	require.NotZero(t, td.epoch)
 	require.NoError(t, td.EnableWriteBackWithMQ(mq, time.Millisecond))
 
 	require.NoError(t, td.UpdateAsync(func() bool {
@@ -357,6 +357,7 @@ func TestDocumentBase_DeleteRecreateFencesOldWriteBack(t *testing.T) {
 	td := &testDoc{ID: "epoch-fence-1", Data: &docPayload{Message: "gen1"}}
 	td.InitWithCache(context.Background(), &td.Data, func() { td.Data = nil }, coll, k, cache)
 	require.NoError(t, td.Create())
+	gen1Epoch := td.epoch
 	require.NoError(t, td.EnableWriteBackWithMQ(mq, 80*time.Millisecond))
 
 	require.NoError(t, td.UpdateAsync(func() bool {
@@ -364,11 +365,12 @@ func TestDocumentBase_DeleteRecreateFencesOldWriteBack(t *testing.T) {
 		return true
 	}))
 
-	// Recreate under a new epoch before the delayed write-back lands.
+	// Recreate on a fresh DocumentBase (normal request boundary) before write-back lands.
 	require.NoError(t, td.Delete())
-	td.Data = &docPayload{Message: "gen2"}
-	require.NoError(t, td.Create())
-	require.Equal(t, int64(2), td.epoch)
+	recreated := &testDoc{ID: "epoch-fence-1", Data: &docPayload{Message: "gen2"}}
+	recreated.InitWithCache(context.Background(), &recreated.Data, func() { recreated.Data = nil }, coll, k, cache)
+	require.NoError(t, recreated.Create())
+	require.NotEqual(t, gen1Epoch, recreated.epoch)
 
 	require.Eventually(t, func() bool {
 		return worker.GetMetrics().FailedCount >= 1
@@ -379,6 +381,42 @@ func TestDocumentBase_DeleteRecreateFencesOldWriteBack(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "gen2", got.Message)
 	require.Equal(t, int64(0), worker.GetMetrics().ProcessedCount)
+}
+
+func TestDocumentBase_SaveAsyncPublishFailureRespectsEpoch(t *testing.T) {
+	t.Parallel()
+
+	logger := zaptest.NewLogger(t)
+	provider := mock.NewMockDriverProvider(logger)
+	coll, err := provider.OpenDbDriver("doc-pub-fail-epoch")
+	require.NoError(t, err)
+
+	k, err := key.NewKeyFromParts("demo", "pub-fail-epoch-1")
+	require.NoError(t, err)
+
+	cache := newMemoryHashCache()
+	mq := &failPublishMQ{}
+	td := &testDoc{ID: "pub-fail-epoch-1", Data: &docPayload{Message: "gen1"}}
+	td.InitWithCache(context.Background(), &td.Data, func() { td.Data = nil }, coll, k, cache)
+	require.NoError(t, td.Create())
+	require.NoError(t, td.EnableWriteBackWithMQ(mq, 40*time.Millisecond))
+
+	require.NoError(t, td.UpdateAsync(func() bool {
+		td.Data.Message = "stale-fallback"
+		return true
+	}))
+
+	require.NoError(t, td.Delete())
+	recreated := &testDoc{ID: "pub-fail-epoch-1", Data: &docPayload{Message: "gen2"}}
+	recreated.InitWithCache(context.Background(), &recreated.Data, func() { recreated.Data = nil }, coll, k, cache)
+	require.NoError(t, recreated.Create())
+
+	time.Sleep(120 * time.Millisecond)
+
+	var got docPayload
+	_, err = coll.Get(context.Background(), k, noptions.WithDestination(&got))
+	require.NoError(t, err)
+	require.Equal(t, "gen2", got.Message)
 }
 
 func TestDocumentBase_ConcurrentUpdates(t *testing.T) {

--- a/orm/nosql/manager.go
+++ b/orm/nosql/manager.go
@@ -2,6 +2,7 @@ package nosql
 
 import (
 	"context"
+	"errors"
 	"sync"
 	"time"
 
@@ -79,16 +80,27 @@ func (m *WriteBackManager) Start() error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	m.logger.Info("Starting WriteBack manager",
-		zap.Int("worker_count", m.config.WorkerCount),
-		zap.Duration("delay", m.config.Delay),
-		zap.Bool("epoch_fence", m.cache != nil),
-	)
 	if m.cache == nil {
-		m.logger.Warn("WriteBack manager started without cache; delete/recreate epoch fencing is disabled")
+		return errors.New("WriteBack manager requires a document cache for epoch fencing")
 	}
 
-	for i := 0; i < m.config.WorkerCount; i++ {
+	// NATS Subscribe currently fans out to every subscriber (no queue group),
+	// so multiple workers would duplicate write-back applies.
+	workerCount := m.config.WorkerCount
+	if workerCount > 1 {
+		m.logger.Warn("WriteBack WorkerCount > 1 is unsupported without queue groups; clamping to 1",
+			zap.Int("configured", workerCount),
+		)
+		workerCount = 1
+	}
+
+	m.logger.Info("Starting WriteBack manager",
+		zap.Int("worker_count", workerCount),
+		zap.Duration("delay", m.config.Delay),
+		zap.Bool("epoch_fence", true),
+	)
+
+	for i := 0; i < workerCount; i++ {
 		worker := NewWriteBackWorker(
 			m.mqClient,
 			m.dbProvider,

--- a/orm/nosql/manager.go
+++ b/orm/nosql/manager.go
@@ -1,0 +1,157 @@
+package nosql
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"go.uber.org/zap"
+
+	"github.com/gstones/moke-kit/mq/miface"
+	"github.com/gstones/moke-kit/orm/nosql/diface"
+)
+
+// WriteBackManager manages multiple write-back workers.
+type WriteBackManager struct {
+	config     WriteBackConfig
+	workers    []*WriteBackWorker
+	mqClient   miface.MessageQueue
+	dbProvider diface.IDocumentProvider
+	logger     *zap.Logger
+	ctx        context.Context
+	cancel     context.CancelFunc
+	mu         sync.RWMutex
+	metrics    WriteBackManagerMetrics
+}
+
+// WriteBackManagerMetrics aggregates manager metrics.
+type WriteBackManagerMetrics struct {
+	TotalProcessed int64         `json:"total_processed"`
+	TotalFailed    int64         `json:"total_failed"`
+	WorkerCount    int           `json:"worker_count"`
+	AverageLatency time.Duration `json:"average_latency"`
+	Uptime         time.Duration `json:"uptime"`
+	StartTime      time.Time     `json:"start_time"`
+}
+
+// NewWriteBackManager creates a write-back manager.
+func NewWriteBackManager(
+	config WriteBackConfig,
+	mqClient miface.MessageQueue,
+	dbProvider diface.IDocumentProvider,
+	logger *zap.Logger,
+) (*WriteBackManager, error) {
+	if err := config.Validate(); err != nil {
+		return nil, err
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	return &WriteBackManager{
+		config:     config,
+		mqClient:   mqClient,
+		dbProvider: dbProvider,
+		logger:     logger,
+		ctx:        ctx,
+		cancel:     cancel,
+		metrics: WriteBackManagerMetrics{
+			StartTime: time.Now(),
+		},
+	}, nil
+}
+
+// Start starts configured workers.
+func (m *WriteBackManager) Start() error {
+	if !m.config.Enabled {
+		m.logger.Info("WriteBack is disabled, skipping start")
+		return nil
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.logger.Info("Starting WriteBack manager",
+		zap.Int("worker_count", m.config.WorkerCount),
+		zap.Duration("delay", m.config.Delay),
+	)
+
+	for i := 0; i < m.config.WorkerCount; i++ {
+		worker := NewWriteBackWorker(
+			m.mqClient,
+			m.dbProvider,
+			m.logger.With(zap.Int("worker_id", i)),
+		)
+		m.workers = append(m.workers, worker)
+		if err := worker.Start(); err != nil {
+			m.logger.Error("Failed to start worker", zap.Int("worker_id", i), zap.Error(err))
+			m.stopWorkers()
+			return err
+		}
+	}
+
+	m.metrics.WorkerCount = len(m.workers)
+	m.logger.Info("WriteBack manager started successfully", zap.Int("workers", len(m.workers)))
+	return nil
+}
+
+// Stop stops the manager and workers.
+func (m *WriteBackManager) Stop() error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.logger.Info("Stopping WriteBack manager")
+	m.cancel()
+	m.stopWorkers()
+	m.logger.Info("WriteBack manager stopped")
+	return nil
+}
+
+func (m *WriteBackManager) stopWorkers() {
+	var wg sync.WaitGroup
+	for i, worker := range m.workers {
+		wg.Add(1)
+		go func(id int, w *WriteBackWorker) {
+			defer wg.Done()
+			w.Stop()
+			m.logger.Debug("Stopped worker", zap.Int("worker_id", id))
+		}(i, worker)
+	}
+	wg.Wait()
+	m.workers = nil
+}
+
+// GetMetrics returns aggregated metrics.
+func (m *WriteBackManager) GetMetrics() WriteBackManagerMetrics {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	metrics := m.metrics
+	metrics.Uptime = time.Since(metrics.StartTime)
+
+	var totalProcessed, totalFailed int64
+	var totalLatency time.Duration
+	workerCount := 0
+	for _, worker := range m.workers {
+		workerMetrics := worker.GetMetrics()
+		totalProcessed += workerMetrics.ProcessedCount
+		totalFailed += workerMetrics.FailedCount
+		totalLatency += workerMetrics.AverageLatency
+		workerCount++
+	}
+	if workerCount > 0 {
+		metrics.AverageLatency = totalLatency / time.Duration(workerCount)
+	}
+	metrics.TotalProcessed = totalProcessed
+	metrics.TotalFailed = totalFailed
+	return metrics
+}
+
+// IsHealthy reports whether the manager looks healthy.
+func (m *WriteBackManager) IsHealthy() bool {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	if !m.config.Enabled {
+		return true
+	}
+	return len(m.workers) > 0
+}

--- a/orm/nosql/manager.go
+++ b/orm/nosql/manager.go
@@ -80,6 +80,9 @@ func (m *WriteBackManager) Start() error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
+	if len(m.workers) > 0 {
+		return errors.New("WriteBack manager already started")
+	}
 	if m.cache == nil {
 		return errors.New("WriteBack manager requires a document cache for epoch fencing")
 	}

--- a/orm/nosql/manager.go
+++ b/orm/nosql/manager.go
@@ -37,8 +37,7 @@ type WriteBackManagerMetrics struct {
 }
 
 // NewWriteBackManager creates a write-back manager.
-// cache may be nil; when set, workers fence delete/recreate generations via __epoch.
-func NewWriteBackManager(
+// When write-back is enabled, cache must be non-nil so workers can fence delete/recreate generations via __epoch.
 	config WriteBackConfig,
 	mqClient miface.MessageQueue,
 	dbProvider diface.IDocumentProvider,

--- a/orm/nosql/manager.go
+++ b/orm/nosql/manager.go
@@ -17,6 +17,7 @@ type WriteBackManager struct {
 	workers    []*WriteBackWorker
 	mqClient   miface.MessageQueue
 	dbProvider diface.IDocumentProvider
+	cache      diface.ICache
 	logger     *zap.Logger
 	ctx        context.Context
 	cancel     context.CancelFunc
@@ -35,11 +36,13 @@ type WriteBackManagerMetrics struct {
 }
 
 // NewWriteBackManager creates a write-back manager.
+// cache may be nil; when set, workers fence delete/recreate generations via __epoch.
 func NewWriteBackManager(
 	config WriteBackConfig,
 	mqClient miface.MessageQueue,
 	dbProvider diface.IDocumentProvider,
 	logger *zap.Logger,
+	cache diface.ICache,
 ) (*WriteBackManager, error) {
 	if err := config.Validate(); err != nil {
 		return nil, err
@@ -50,6 +53,7 @@ func NewWriteBackManager(
 		config:     config,
 		mqClient:   mqClient,
 		dbProvider: dbProvider,
+		cache:      cache,
 		logger:     logger,
 		ctx:        ctx,
 		cancel:     cancel,
@@ -57,6 +61,12 @@ func NewWriteBackManager(
 			StartTime: time.Now(),
 		},
 	}, nil
+}
+
+// WithCache attaches a document cache used by workers for epoch fencing.
+func (m *WriteBackManager) WithCache(cache diface.ICache) *WriteBackManager {
+	m.cache = cache
+	return m
 }
 
 // Start starts configured workers.
@@ -72,14 +82,18 @@ func (m *WriteBackManager) Start() error {
 	m.logger.Info("Starting WriteBack manager",
 		zap.Int("worker_count", m.config.WorkerCount),
 		zap.Duration("delay", m.config.Delay),
+		zap.Bool("epoch_fence", m.cache != nil),
 	)
+	if m.cache == nil {
+		m.logger.Warn("WriteBack manager started without cache; delete/recreate epoch fencing is disabled")
+	}
 
 	for i := 0; i < m.config.WorkerCount; i++ {
 		worker := NewWriteBackWorker(
 			m.mqClient,
 			m.dbProvider,
 			m.logger.With(zap.Int("worker_id", i)),
-		)
+		).WithCache(m.cache)
 		m.workers = append(m.workers, worker)
 		if err := worker.Start(); err != nil {
 			m.logger.Error("Failed to start worker", zap.Int("worker_id", i), zap.Error(err))

--- a/orm/nosql/mock/internal/provider.go
+++ b/orm/nosql/mock/internal/provider.go
@@ -1,6 +1,8 @@
 package internal
 
 import (
+	"sync"
+
 	"go.uber.org/zap"
 
 	"github.com/gstones/moke-kit/orm/nosql/diface"
@@ -8,6 +10,8 @@ import (
 
 type MockDriverProvider struct {
 	logger *zap.Logger
+	mu     sync.Mutex
+	cols   map[string]*MockCollection
 }
 
 func (dp *MockDriverProvider) Shutdown() error {
@@ -15,13 +19,24 @@ func (dp *MockDriverProvider) Shutdown() error {
 }
 
 func (dp *MockDriverProvider) OpenDbDriver(name string) (diface.ICollection, error) {
+	dp.mu.Lock()
+	defer dp.mu.Unlock()
+	if dp.cols == nil {
+		dp.cols = make(map[string]*MockCollection)
+	}
+	if mc, ok := dp.cols[name]; ok {
+		return mc, nil
+	}
 	mc := NewMockCollection(name)
+	dp.cols[name] = mc
 	return mc, nil
 }
 
 func NewMockDriverProvider(
 	logger *zap.Logger,
 ) *MockDriverProvider {
-	m := &MockDriverProvider{logger: logger}
-	return m
+	return &MockDriverProvider{
+		logger: logger,
+		cols:   make(map[string]*MockCollection),
+	}
 }

--- a/orm/nosql/noptions/options.go
+++ b/orm/nosql/noptions/options.go
@@ -93,7 +93,7 @@ func WithDestination(dst any) Option {
 		if dst == nil {
 			return nerrors.ErrDestIsNil
 		}
-		if reflect.TypeOf(dst).Kind() != reflect.Ptr {
+		if reflect.TypeOf(dst).Kind() != reflect.Pointer {
 			return nerrors.ErrDestMustBePointer
 		}
 		o.Destination = dst

--- a/orm/nosql/noptions/options.go
+++ b/orm/nosql/noptions/options.go
@@ -93,7 +93,7 @@ func WithDestination(dst any) Option {
 		if dst == nil {
 			return nerrors.ErrDestIsNil
 		}
-		if reflect.TypeOf(dst).Kind() != reflect.Pointer {
+		if reflect.TypeOf(dst).Kind() != reflect.Ptr {
 			return nerrors.ErrDestMustBePointer
 		}
 		o.Destination = dst

--- a/orm/nosql/worker.go
+++ b/orm/nosql/worker.go
@@ -100,17 +100,19 @@ func isVersionMismatch(err error) bool {
 	return strings.Contains(msg, "version mismatch") || strings.Contains(msg, "ErrVersionNotMatch")
 }
 
-func (w *WriteBackWorker) epochMismatch(ctx context.Context, docKey key.Key, payload WriteBackPayload) bool {
-	if w.cache == nil || payload.Epoch == 0 {
+// cacheEpochMismatch reports whether payloadEpoch conflicts with the cached generation.
+// Returns false when cache is nil, epoch is 0, or the cache entry has no epoch field
+// (e.g. Load-from-DB after restart).
+func cacheEpochMismatch(ctx context.Context, cache diface.ICache, docKey key.Key, payloadEpoch int64) bool {
+	if cache == nil || payloadEpoch == 0 {
 		return false
 	}
-	cached := w.cache.GetCache(ctx, docKey, cacheFieldEpoch)
+	cached := cache.GetCache(ctx, docKey, cacheFieldEpoch)
 	ep, ok := parseCacheVersion(cached[cacheFieldEpoch])
 	if !ok {
-		// No cached epoch (e.g. Load-from-DB after restart): do not fence.
 		return false
 	}
-	return ep != payload.Epoch
+	return ep != payloadEpoch
 }
 
 func (w *WriteBackWorker) consumeWriteBack(
@@ -120,7 +122,7 @@ func (w *WriteBackWorker) consumeWriteBack(
 	src any,
 	payload WriteBackPayload,
 ) common.ConsumptionCode {
-	if w.epochMismatch(ctx, docKey, payload) {
+	if cacheEpochMismatch(ctx, w.cache, docKey, payload.Epoch) {
 		w.failedCount.Add(1)
 		w.logger.Warn("WriteBack epoch mismatch; dropping message",
 			zap.String("key", payload.Key),

--- a/orm/nosql/worker.go
+++ b/orm/nosql/worker.go
@@ -97,14 +97,14 @@ func (w *WriteBackWorker) handleVersionMismatch(
 	ctx context.Context,
 	coll diface.ICollection,
 	docKey key.Key,
+	src any,
 	payload WriteBackPayload,
 	setErr error,
 ) common.ConsumptionCode {
-	w.failedCount.Add(1)
-
 	var discard any
 	current, err := coll.Get(ctx, docKey, noptions.WithDestination(&discard))
 	if err != nil {
+		w.failedCount.Add(1)
 		if errors.Is(err, nerrors.ErrNotFound) {
 			w.logger.Warn("WriteBack target missing; dropping message",
 				zap.String("key", payload.Key),
@@ -121,6 +121,7 @@ func (w *WriteBackWorker) handleVersionMismatch(
 
 	// Stale snapshot: a newer write already landed.
 	if payload.Version < current {
+		w.failedCount.Add(1)
 		w.logger.Warn("WriteBack snapshot is stale; dropping message",
 			zap.String("key", payload.Key),
 			zap.Int64("payload_version", int64(payload.Version)),
@@ -129,14 +130,31 @@ func (w *WriteBackWorker) handleVersionMismatch(
 		return common.ConsumeNackPersistentFailure
 	}
 
-	// Out-of-order delivery: an earlier write-back has not been applied yet.
-	w.logger.Warn("WriteBack arrived early; will retry",
+	// Missing earlier write-back (publish lost / recreated doc / gap): rebase the
+	// full snapshot onto the current DB version instead of nacking forever.
+	w.logger.Warn("WriteBack rebasing onto current version",
 		zap.String("key", payload.Key),
 		zap.Int64("payload_version", int64(payload.Version)),
 		zap.Int64("current_version", int64(current)),
 		zap.Error(setErr),
 	)
-	return common.ConsumeNackTransientFailure
+	if _, rebaseErr := coll.Set(
+		ctx,
+		docKey,
+		noptions.WithSource(src),
+		noptions.WithVersion(current),
+	); rebaseErr != nil {
+		w.failedCount.Add(1)
+		if isVersionMismatch(rebaseErr) {
+			// Concurrent writer raced the rebase; one bounded retry via MQ is enough.
+			return common.ConsumeNackTransientFailure
+		}
+		return w.handleError(rebaseErr, payload)
+	}
+
+	w.processedCount.Add(1)
+	w.lastProcessed.Store(time.Now())
+	return common.ConsumeAck
 }
 
 func (w *WriteBackWorker) handleError(err error, payload WriteBackPayload) common.ConsumptionCode {
@@ -213,7 +231,7 @@ func (w *WriteBackWorker) Start() error {
 				zap.Duration("latency", latency),
 			)
 			if isVersionMismatch(setErr) {
-				return w.handleVersionMismatch(dbCtx, coll, docKey, payload, setErr)
+				return w.handleVersionMismatch(dbCtx, coll, docKey, src, payload, setErr)
 			}
 			return w.handleError(setErr, payload)
 		}

--- a/orm/nosql/worker.go
+++ b/orm/nosql/worker.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/gstones/moke-kit/mq/common"
 	"github.com/gstones/moke-kit/mq/miface"
+	"github.com/gstones/moke-kit/orm/nerrors"
 	"github.com/gstones/moke-kit/orm/nosql/diface"
 	"github.com/gstones/moke-kit/orm/nosql/key"
 	"github.com/gstones/moke-kit/orm/nosql/noptions"
@@ -81,6 +82,63 @@ func (w *WriteBackWorker) GetMetrics() WriteBackMetrics {
 	}
 }
 
+func isVersionMismatch(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, nerrors.ErrVersionNotMatch) {
+		return true
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "version mismatch") || strings.Contains(msg, "ErrVersionNotMatch")
+}
+
+func (w *WriteBackWorker) handleVersionMismatch(
+	ctx context.Context,
+	coll diface.ICollection,
+	docKey key.Key,
+	payload WriteBackPayload,
+	setErr error,
+) common.ConsumptionCode {
+	w.failedCount.Add(1)
+
+	var discard any
+	current, err := coll.Get(ctx, docKey, noptions.WithDestination(&discard))
+	if err != nil {
+		if errors.Is(err, nerrors.ErrNotFound) {
+			w.logger.Warn("WriteBack target missing; dropping message",
+				zap.String("key", payload.Key),
+				zap.Error(setErr),
+			)
+			return common.ConsumeNackPersistentFailure
+		}
+		w.logger.Warn("WriteBack version check failed; will retry",
+			zap.String("key", payload.Key),
+			zap.Error(err),
+		)
+		return common.ConsumeNackTransientFailure
+	}
+
+	// Stale snapshot: a newer write already landed.
+	if payload.Version < current {
+		w.logger.Warn("WriteBack snapshot is stale; dropping message",
+			zap.String("key", payload.Key),
+			zap.Int64("payload_version", int64(payload.Version)),
+			zap.Int64("current_version", int64(current)),
+		)
+		return common.ConsumeNackPersistentFailure
+	}
+
+	// Out-of-order delivery: an earlier write-back has not been applied yet.
+	w.logger.Warn("WriteBack arrived early; will retry",
+		zap.String("key", payload.Key),
+		zap.Int64("payload_version", int64(payload.Version)),
+		zap.Int64("current_version", int64(current)),
+		zap.Error(setErr),
+	)
+	return common.ConsumeNackTransientFailure
+}
+
 func (w *WriteBackWorker) handleError(err error, payload WriteBackPayload) common.ConsumptionCode {
 	w.failedCount.Add(1)
 	w.logger.Error("WriteBack operation failed",
@@ -92,9 +150,6 @@ func (w *WriteBackWorker) handleError(err error, payload WriteBackPayload) commo
 	switch {
 	case errors.Is(err, context.DeadlineExceeded):
 		return common.ConsumeNackTransientFailure
-	case strings.Contains(err.Error(), "version mismatch") ||
-		strings.Contains(err.Error(), "ErrVersionNotMatch"):
-		return common.ConsumeNackPersistentFailure
 	case strings.Contains(err.Error(), "connection"):
 		return common.ConsumeNackTransientFailure
 	default:
@@ -113,6 +168,15 @@ func (w *WriteBackWorker) Start() error {
 		var payload WriteBackPayload
 		if err := json.Unmarshal(msg.Data(), &payload); err != nil {
 			w.logger.Error("Failed to unmarshal message", zap.Error(err))
+			return common.ConsumeNackPersistentFailure
+		}
+
+		docKey, keyErr := key.NewKeyFromString(payload.Key)
+		if keyErr != nil {
+			w.logger.Error("Invalid write-back key",
+				zap.String("key", payload.Key),
+				zap.Error(keyErr),
+			)
 			return common.ConsumeNackPersistentFailure
 		}
 
@@ -137,7 +201,7 @@ func (w *WriteBackWorker) Start() error {
 		startTime := time.Now()
 		_, setErr := coll.Set(
 			dbCtx,
-			key.NewKey(payload.Key),
+			docKey,
 			noptions.WithSource(src),
 			noptions.WithVersion(payload.Version),
 		)
@@ -148,6 +212,9 @@ func (w *WriteBackWorker) Start() error {
 				zap.Error(setErr),
 				zap.Duration("latency", latency),
 			)
+			if isVersionMismatch(setErr) {
+				return w.handleVersionMismatch(dbCtx, coll, docKey, payload, setErr)
+			}
 			return w.handleError(setErr, payload)
 		}
 
@@ -157,14 +224,14 @@ func (w *WriteBackWorker) Start() error {
 		return common.ConsumeAck
 	}
 
+	consumer, err := w.mqClient.Subscribe(w.ctx, WriteBackTopic, handler)
+	if err != nil {
+		return err
+	}
+
 	w.wg.Add(1)
 	go func() {
 		defer w.wg.Done()
-		consumer, err := w.mqClient.Subscribe(w.ctx, WriteBackTopic, handler)
-		if err != nil {
-			w.logger.Error("Failed to subscribe to writeback topic", zap.Error(err))
-			return
-		}
 		<-w.ctx.Done()
 		if consumer != nil {
 			_ = consumer.Unsubscribe()

--- a/orm/nosql/worker.go
+++ b/orm/nosql/worker.go
@@ -16,7 +16,6 @@ import (
 	"github.com/gstones/moke-kit/orm/nerrors"
 	"github.com/gstones/moke-kit/orm/nosql/diface"
 	"github.com/gstones/moke-kit/orm/nosql/key"
-	"github.com/gstones/moke-kit/orm/nosql/noptions"
 )
 
 // WriteBackWorker consumes delayed write-back messages and persists them.
@@ -93,20 +92,13 @@ func isVersionMismatch(err error) bool {
 	return strings.Contains(msg, "version mismatch") || strings.Contains(msg, "ErrVersionNotMatch")
 }
 
-func (w *WriteBackWorker) handleVersionMismatch(
+func (w *WriteBackWorker) consumeWriteBack(
 	ctx context.Context,
 	coll diface.ICollection,
 	docKey key.Key,
 	src any,
 	payload WriteBackPayload,
-	setErr error,
 ) common.ConsumptionCode {
-	w.logger.Warn("WriteBack CAS mismatch; attempting bounded rebase",
-		zap.String("key", payload.Key),
-		zap.Int64("payload_version", int64(payload.Version)),
-		zap.Error(setErr),
-	)
-
 	err := applyWriteBackSnapshot(ctx, coll, docKey, src, payload.Version)
 	if err == nil {
 		w.processedCount.Add(1)
@@ -115,11 +107,11 @@ func (w *WriteBackWorker) handleVersionMismatch(
 	}
 
 	switch {
-	case errors.Is(err, errWriteBackStale), errors.Is(err, errWriteBackAmbiguousGap):
+	case errors.Is(err, errWriteBackStale):
 		w.failedCount.Add(1)
-		w.logger.Warn("WriteBack snapshot rejected",
+		w.logger.Warn("WriteBack snapshot is stale; dropping message",
 			zap.String("key", payload.Key),
-			zap.Int64("payload_version", int64(payload.Version)),
+			zap.Int64("target_version", int64(payload.Version)),
 			zap.Error(err),
 		)
 		return common.ConsumeNackPersistentFailure
@@ -132,7 +124,7 @@ func (w *WriteBackWorker) handleVersionMismatch(
 		return common.ConsumeNackPersistentFailure
 	case isVersionMismatch(err):
 		w.failedCount.Add(1)
-		// Concurrent writer raced the rebase; one bounded retry via MQ is enough.
+		// Concurrent writer raced the apply; one bounded retry via MQ is enough.
 		return common.ConsumeNackTransientFailure
 	default:
 		return w.handleError(err, payload)
@@ -199,29 +191,9 @@ func (w *WriteBackWorker) Start() error {
 		defer dbCancel()
 
 		startTime := time.Now()
-		_, setErr := coll.Set(
-			dbCtx,
-			docKey,
-			noptions.WithSource(src),
-			noptions.WithVersion(payload.Version),
-		)
-		latency := time.Since(startTime)
-		if setErr != nil {
-			w.logger.Error("Failed to write back document",
-				zap.String("key", payload.Key),
-				zap.Error(setErr),
-				zap.Duration("latency", latency),
-			)
-			if isVersionMismatch(setErr) {
-				return w.handleVersionMismatch(dbCtx, coll, docKey, src, payload, setErr)
-			}
-			return w.handleError(setErr, payload)
-		}
-
-		w.processedCount.Add(1)
-		w.totalLatency.Add(int64(latency))
-		w.lastProcessed.Store(time.Now())
-		return common.ConsumeAck
+		code := w.consumeWriteBack(dbCtx, coll, docKey, src, payload)
+		w.totalLatency.Add(int64(time.Since(startTime)))
+		return code
 	}
 
 	consumer, err := w.mqClient.Subscribe(w.ctx, WriteBackTopic, handler)

--- a/orm/nosql/worker.go
+++ b/orm/nosql/worker.go
@@ -122,17 +122,7 @@ func (w *WriteBackWorker) consumeWriteBack(
 	src any,
 	payload WriteBackPayload,
 ) common.ConsumptionCode {
-	if cacheEpochMismatch(ctx, w.cache, docKey, payload.Epoch) {
-		w.failedCount.Add(1)
-		w.logger.Warn("WriteBack epoch mismatch; dropping message",
-			zap.String("key", payload.Key),
-			zap.Int64("payload_epoch", payload.Epoch),
-			zap.Int64("target_version", int64(payload.Version)),
-		)
-		return common.ConsumeNackPersistentFailure
-	}
-
-	err := applyWriteBackSnapshot(ctx, coll, docKey, src, payload.Version)
+	err := applyWriteBackSnapshot(ctx, coll, docKey, src, payload.Version, w.cache, payload.Epoch)
 	if err == nil {
 		w.processedCount.Add(1)
 		w.lastProcessed.Store(time.Now())
@@ -140,6 +130,14 @@ func (w *WriteBackWorker) consumeWriteBack(
 	}
 
 	switch {
+	case errors.Is(err, errWriteBackEpoch):
+		w.failedCount.Add(1)
+		w.logger.Warn("WriteBack epoch mismatch; dropping message",
+			zap.String("key", payload.Key),
+			zap.Int64("payload_epoch", payload.Epoch),
+			zap.Int64("target_version", int64(payload.Version)),
+		)
+		return common.ConsumeNackPersistentFailure
 	case errors.Is(err, errWriteBackStale):
 		w.failedCount.Add(1)
 		w.logger.Warn("WriteBack snapshot is stale; dropping message",

--- a/orm/nosql/worker.go
+++ b/orm/nosql/worker.go
@@ -1,0 +1,190 @@
+package nosql
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"go.uber.org/zap"
+
+	"github.com/gstones/moke-kit/mq/common"
+	"github.com/gstones/moke-kit/mq/miface"
+	"github.com/gstones/moke-kit/orm/nosql/diface"
+	"github.com/gstones/moke-kit/orm/nosql/key"
+	"github.com/gstones/moke-kit/orm/nosql/noptions"
+)
+
+// WriteBackWorker consumes delayed write-back messages and persists them.
+type WriteBackWorker struct {
+	ctx        context.Context
+	cancel     context.CancelFunc
+	mqClient   miface.MessageQueue
+	dbProvider diface.IDocumentProvider
+	logger     *zap.Logger
+	wg         sync.WaitGroup
+
+	processedCount atomic.Int64
+	failedCount    atomic.Int64
+	totalLatency   atomic.Int64
+	lastProcessed  atomic.Value
+}
+
+// NewWriteBackWorker creates a write-back worker.
+func NewWriteBackWorker(
+	mqClient miface.MessageQueue,
+	dbProvider diface.IDocumentProvider,
+	logger *zap.Logger,
+) *WriteBackWorker {
+	ctx, cancel := context.WithCancel(context.Background())
+	return &WriteBackWorker{
+		ctx:        ctx,
+		cancel:     cancel,
+		mqClient:   mqClient,
+		dbProvider: dbProvider,
+		logger:     logger,
+	}
+}
+
+// WriteBackMetrics exposes worker counters.
+type WriteBackMetrics struct {
+	ProcessedCount int64         `json:"processed_count"`
+	FailedCount    int64         `json:"failed_count"`
+	AverageLatency time.Duration `json:"average_latency"`
+	LastProcessed  time.Time     `json:"last_processed"`
+}
+
+// GetMetrics returns worker metrics.
+func (w *WriteBackWorker) GetMetrics() WriteBackMetrics {
+	processed := w.processedCount.Load()
+	failed := w.failedCount.Load()
+	totalLatency := w.totalLatency.Load()
+
+	var avgLatency time.Duration
+	if processed > 0 {
+		avgLatency = time.Duration(totalLatency / processed)
+	}
+
+	var lastProcessed time.Time
+	if val := w.lastProcessed.Load(); val != nil {
+		lastProcessed = val.(time.Time)
+	}
+
+	return WriteBackMetrics{
+		ProcessedCount: processed,
+		FailedCount:    failed,
+		AverageLatency: avgLatency,
+		LastProcessed:  lastProcessed,
+	}
+}
+
+func (w *WriteBackWorker) handleError(err error, payload WriteBackPayload) common.ConsumptionCode {
+	w.failedCount.Add(1)
+	w.logger.Error("WriteBack operation failed",
+		zap.Error(err),
+		zap.String("collection", payload.CollectionName),
+		zap.String("key", payload.Key),
+	)
+
+	switch {
+	case errors.Is(err, context.DeadlineExceeded):
+		return common.ConsumeNackTransientFailure
+	case strings.Contains(err.Error(), "version mismatch") ||
+		strings.Contains(err.Error(), "ErrVersionNotMatch"):
+		return common.ConsumeNackPersistentFailure
+	case strings.Contains(err.Error(), "connection"):
+		return common.ConsumeNackTransientFailure
+	default:
+		return common.ConsumeNackTransientFailure
+	}
+}
+
+// Start subscribes to the write-back topic.
+func (w *WriteBackWorker) Start() error {
+	handler := func(msg miface.Message, err error) common.ConsumptionCode {
+		if err != nil {
+			w.logger.Error("WriteBack subscription error", zap.Error(err))
+			return common.ConsumeNackTransientFailure
+		}
+
+		var payload WriteBackPayload
+		if err := json.Unmarshal(msg.Data(), &payload); err != nil {
+			w.logger.Error("Failed to unmarshal message", zap.Error(err))
+			return common.ConsumeNackPersistentFailure
+		}
+
+		coll, e := w.dbProvider.OpenDbDriver(payload.CollectionName)
+		if e != nil {
+			w.logger.Error("Failed to open collection",
+				zap.String("collection", payload.CollectionName),
+				zap.Error(e),
+			)
+			return common.ConsumeNackPersistentFailure
+		}
+
+		var src any
+		if err := json.Unmarshal(payload.Data, &src); err != nil {
+			w.logger.Error("Failed to decode write-back data", zap.Error(err))
+			return common.ConsumeNackPersistentFailure
+		}
+
+		dbCtx, dbCancel := context.WithTimeout(w.ctx, 30*time.Second)
+		defer dbCancel()
+
+		startTime := time.Now()
+		_, setErr := coll.Set(
+			dbCtx,
+			key.NewKey(payload.Key),
+			noptions.WithSource(src),
+			noptions.WithVersion(payload.Version),
+		)
+		latency := time.Since(startTime)
+		if setErr != nil {
+			w.logger.Error("Failed to write back document",
+				zap.String("key", payload.Key),
+				zap.Error(setErr),
+				zap.Duration("latency", latency),
+			)
+			return w.handleError(setErr, payload)
+		}
+
+		w.processedCount.Add(1)
+		w.totalLatency.Add(int64(latency))
+		w.lastProcessed.Store(time.Now())
+		return common.ConsumeAck
+	}
+
+	w.wg.Add(1)
+	go func() {
+		defer w.wg.Done()
+		consumer, err := w.mqClient.Subscribe(w.ctx, WriteBackTopic, handler)
+		if err != nil {
+			w.logger.Error("Failed to subscribe to writeback topic", zap.Error(err))
+			return
+		}
+		<-w.ctx.Done()
+		if consumer != nil {
+			_ = consumer.Unsubscribe()
+		}
+	}()
+
+	return nil
+}
+
+// Stop stops the worker.
+func (w *WriteBackWorker) Stop() {
+	w.cancel()
+	done := make(chan struct{})
+	go func() {
+		w.wg.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		w.logger.Warn("Timeout waiting for writeback worker to stop")
+	}
+}

--- a/orm/nosql/worker.go
+++ b/orm/nosql/worker.go
@@ -101,60 +101,42 @@ func (w *WriteBackWorker) handleVersionMismatch(
 	payload WriteBackPayload,
 	setErr error,
 ) common.ConsumptionCode {
-	var discard any
-	current, err := coll.Get(ctx, docKey, noptions.WithDestination(&discard))
-	if err != nil {
+	w.logger.Warn("WriteBack CAS mismatch; attempting bounded rebase",
+		zap.String("key", payload.Key),
+		zap.Int64("payload_version", int64(payload.Version)),
+		zap.Error(setErr),
+	)
+
+	err := applyWriteBackSnapshot(ctx, coll, docKey, src, payload.Version)
+	if err == nil {
+		w.processedCount.Add(1)
+		w.lastProcessed.Store(time.Now())
+		return common.ConsumeAck
+	}
+
+	switch {
+	case errors.Is(err, errWriteBackStale), errors.Is(err, errWriteBackAmbiguousGap):
 		w.failedCount.Add(1)
-		if errors.Is(err, nerrors.ErrNotFound) {
-			w.logger.Warn("WriteBack target missing; dropping message",
-				zap.String("key", payload.Key),
-				zap.Error(setErr),
-			)
-			return common.ConsumeNackPersistentFailure
-		}
-		w.logger.Warn("WriteBack version check failed; will retry",
+		w.logger.Warn("WriteBack snapshot rejected",
+			zap.String("key", payload.Key),
+			zap.Int64("payload_version", int64(payload.Version)),
+			zap.Error(err),
+		)
+		return common.ConsumeNackPersistentFailure
+	case errors.Is(err, nerrors.ErrNotFound):
+		w.failedCount.Add(1)
+		w.logger.Warn("WriteBack target missing; dropping message",
 			zap.String("key", payload.Key),
 			zap.Error(err),
 		)
-		return common.ConsumeNackTransientFailure
-	}
-
-	// Stale snapshot: a newer write already landed.
-	if payload.Version < current {
-		w.failedCount.Add(1)
-		w.logger.Warn("WriteBack snapshot is stale; dropping message",
-			zap.String("key", payload.Key),
-			zap.Int64("payload_version", int64(payload.Version)),
-			zap.Int64("current_version", int64(current)),
-		)
 		return common.ConsumeNackPersistentFailure
-	}
-
-	// Missing earlier write-back (publish lost / recreated doc / gap): rebase the
-	// full snapshot onto the current DB version instead of nacking forever.
-	w.logger.Warn("WriteBack rebasing onto current version",
-		zap.String("key", payload.Key),
-		zap.Int64("payload_version", int64(payload.Version)),
-		zap.Int64("current_version", int64(current)),
-		zap.Error(setErr),
-	)
-	if _, rebaseErr := coll.Set(
-		ctx,
-		docKey,
-		noptions.WithSource(src),
-		noptions.WithVersion(current),
-	); rebaseErr != nil {
+	case isVersionMismatch(err):
 		w.failedCount.Add(1)
-		if isVersionMismatch(rebaseErr) {
-			// Concurrent writer raced the rebase; one bounded retry via MQ is enough.
-			return common.ConsumeNackTransientFailure
-		}
-		return w.handleError(rebaseErr, payload)
+		// Concurrent writer raced the rebase; one bounded retry via MQ is enough.
+		return common.ConsumeNackTransientFailure
+	default:
+		return w.handleError(err, payload)
 	}
-
-	w.processedCount.Add(1)
-	w.lastProcessed.Store(time.Now())
-	return common.ConsumeAck
 }
 
 func (w *WriteBackWorker) handleError(err error, payload WriteBackPayload) common.ConsumptionCode {

--- a/orm/nosql/worker.go
+++ b/orm/nosql/worker.go
@@ -24,6 +24,7 @@ type WriteBackWorker struct {
 	cancel     context.CancelFunc
 	mqClient   miface.MessageQueue
 	dbProvider diface.IDocumentProvider
+	cache      diface.ICache
 	logger     *zap.Logger
 	wg         sync.WaitGroup
 
@@ -47,6 +48,13 @@ func NewWriteBackWorker(
 		dbProvider: dbProvider,
 		logger:     logger,
 	}
+}
+
+// WithCache attaches a document cache used to fence delete/recreate generations via __epoch.
+// When unset, workers rely only on target-version freshness checks.
+func (w *WriteBackWorker) WithCache(cache diface.ICache) *WriteBackWorker {
+	w.cache = cache
+	return w
 }
 
 // WriteBackMetrics exposes worker counters.
@@ -92,6 +100,19 @@ func isVersionMismatch(err error) bool {
 	return strings.Contains(msg, "version mismatch") || strings.Contains(msg, "ErrVersionNotMatch")
 }
 
+func (w *WriteBackWorker) epochMismatch(ctx context.Context, docKey key.Key, payload WriteBackPayload) bool {
+	if w.cache == nil || payload.Epoch == 0 {
+		return false
+	}
+	cached := w.cache.GetCache(ctx, docKey, cacheFieldEpoch)
+	ep, ok := parseCacheVersion(cached[cacheFieldEpoch])
+	if !ok {
+		// No cached epoch (e.g. Load-from-DB after restart): do not fence.
+		return false
+	}
+	return ep != payload.Epoch
+}
+
 func (w *WriteBackWorker) consumeWriteBack(
 	ctx context.Context,
 	coll diface.ICollection,
@@ -99,6 +120,16 @@ func (w *WriteBackWorker) consumeWriteBack(
 	src any,
 	payload WriteBackPayload,
 ) common.ConsumptionCode {
+	if w.epochMismatch(ctx, docKey, payload) {
+		w.failedCount.Add(1)
+		w.logger.Warn("WriteBack epoch mismatch; dropping message",
+			zap.String("key", payload.Key),
+			zap.Int64("payload_epoch", payload.Epoch),
+			zap.Int64("target_version", int64(payload.Version)),
+		)
+		return common.ConsumeNackPersistentFailure
+	}
+
 	err := applyWriteBackSnapshot(ctx, coll, docKey, src, payload.Version)
 	if err == nil {
 		w.processedCount.Add(1)

--- a/orm/nosql/writeback_test.go
+++ b/orm/nosql/writeback_test.go
@@ -185,7 +185,7 @@ func (c *jumpOnSecondGetCollection) Get(
 		if err != nil {
 			return ver, err
 		}
-		_, err = c.ICollection.Set(
+		_, err = c.Set(
 			ctx,
 			k,
 			noptions.WithSource(&docPayload{Message: "external"}),

--- a/orm/nosql/writeback_test.go
+++ b/orm/nosql/writeback_test.go
@@ -10,6 +10,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/gstones/moke-kit/mq/miface"
+	"github.com/gstones/moke-kit/orm/nosql/key"
 	"github.com/gstones/moke-kit/orm/nosql/mock"
 	"github.com/gstones/moke-kit/orm/nosql/noptions"
 )
@@ -121,6 +122,41 @@ func TestWriteBackWorker_StartSubscribeError(t *testing.T) {
 		zap.NewNop(),
 	)
 	assert.Error(t, worker.Start())
+}
+
+func TestWriteBackWorker_RebaseOnVersionGap(t *testing.T) {
+	logger := zap.NewNop()
+	provider := mock.NewMockDriverProvider(logger)
+	coll, err := provider.OpenDbDriver("wb-rebase")
+	assert.NoError(t, err)
+
+	k, err := key.NewKeyFromParts("demo", "rebase-1")
+	assert.NoError(t, err)
+
+	_, err = coll.Set(context.Background(), k, noptions.WithSource(&docPayload{Message: "v1"}))
+	assert.NoError(t, err)
+
+	mq := &capturingMQ{}
+	worker := NewWriteBackWorker(mq, provider, logger)
+	assert.NoError(t, worker.Start())
+	defer worker.Stop()
+
+	assert.NoError(t, mq.Publish(WriteBackTopic, miface.WithJSON(&WriteBackPayload{
+		CollectionName: "wb-rebase",
+		Key:            k.String(),
+		Data:           json.RawMessage(`{"message":"rebased"}`),
+		Version:        5, // gap: earlier write-backs never arrived
+	})))
+
+	assert.Eventually(t, func() bool {
+		return worker.GetMetrics().ProcessedCount >= 1
+	}, time.Second, 10*time.Millisecond)
+
+	var got docPayload
+	ver, err := coll.Get(context.Background(), k, noptions.WithDestination(&got))
+	assert.NoError(t, err)
+	assert.Equal(t, "rebased", got.Message)
+	assert.Equal(t, noptions.Version(2), ver)
 }
 
 func TestWriteBackPayload_JSON(t *testing.T) {

--- a/orm/nosql/writeback_test.go
+++ b/orm/nosql/writeback_test.go
@@ -124,7 +124,7 @@ func TestWriteBackWorker_StartSubscribeError(t *testing.T) {
 	assert.Error(t, worker.Start())
 }
 
-func TestWriteBackWorker_RebaseOnAdjacentVersionGap(t *testing.T) {
+func TestWriteBackWorker_ApplyNewerTargetVersion(t *testing.T) {
 	logger := zap.NewNop()
 	provider := mock.NewMockDriverProvider(logger)
 	coll, err := provider.OpenDbDriver("wb-rebase")
@@ -141,34 +141,48 @@ func TestWriteBackWorker_RebaseOnAdjacentVersionGap(t *testing.T) {
 	assert.NoError(t, worker.Start())
 	defer worker.Stop()
 
+	// Newer target arrives first (rapid SaveAsync / reordered MQ).
 	assert.NoError(t, mq.Publish(WriteBackTopic, miface.WithJSON(&WriteBackPayload{
 		CollectionName: "wb-rebase",
 		Key:            k.String(),
-		Data:           json.RawMessage(`{"message":"rebased"}`),
-		Version:        2, // exactly one ahead: safe adjacent rebase
+		Data:           json.RawMessage(`{"message":"latest"}`),
+		Version:        5,
+	})))
+	assert.NoError(t, mq.Publish(WriteBackTopic, miface.WithJSON(&WriteBackPayload{
+		CollectionName: "wb-rebase",
+		Key:            k.String(),
+		Data:           json.RawMessage(`{"message":"older"}`),
+		Version:        2,
 	})))
 
 	assert.Eventually(t, func() bool {
-		return worker.GetMetrics().ProcessedCount >= 1
+		return worker.GetMetrics().ProcessedCount >= 1 && worker.GetMetrics().FailedCount >= 1
 	}, time.Second, 10*time.Millisecond)
 
 	var got docPayload
 	ver, err := coll.Get(context.Background(), k, noptions.WithDestination(&got))
 	assert.NoError(t, err)
-	assert.Equal(t, "rebased", got.Message)
+	assert.Equal(t, "latest", got.Message)
 	assert.Equal(t, noptions.Version(2), ver)
 }
 
-func TestWriteBackWorker_RejectAmbiguousVersionGap(t *testing.T) {
+func TestWriteBackWorker_RejectStaleTargetVersion(t *testing.T) {
 	logger := zap.NewNop()
 	provider := mock.NewMockDriverProvider(logger)
-	coll, err := provider.OpenDbDriver("wb-gap")
+	coll, err := provider.OpenDbDriver("wb-stale")
 	assert.NoError(t, err)
 
-	k, err := key.NewKeyFromParts("demo", "gap-1")
+	k, err := key.NewKeyFromParts("demo", "stale-1")
 	assert.NoError(t, err)
 
-	_, err = coll.Set(context.Background(), k, noptions.WithSource(&docPayload{Message: "fresh"}))
+	_, err = coll.Set(context.Background(), k, noptions.WithSource(&docPayload{Message: "seed"}))
+	assert.NoError(t, err)
+	_, err = coll.Set(
+		context.Background(),
+		k,
+		noptions.WithSource(&docPayload{Message: "fresh"}),
+		noptions.WithVersion(1),
+	)
 	assert.NoError(t, err)
 
 	mq := &capturingMQ{}
@@ -177,10 +191,10 @@ func TestWriteBackWorker_RejectAmbiguousVersionGap(t *testing.T) {
 	defer worker.Stop()
 
 	assert.NoError(t, mq.Publish(WriteBackTopic, miface.WithJSON(&WriteBackPayload{
-		CollectionName: "wb-gap",
+		CollectionName: "wb-stale",
 		Key:            k.String(),
-		Data:           json.RawMessage(`{"message":"stale-inflight"}`),
-		Version:        9, // large gap: treat as ambiguous / possible recreate
+		Data:           json.RawMessage(`{"message":"stale"}`),
+		Version:        2, // not newer than current DB version 2
 	})))
 
 	assert.Eventually(t, func() bool {

--- a/orm/nosql/writeback_test.go
+++ b/orm/nosql/writeback_test.go
@@ -124,7 +124,7 @@ func TestWriteBackWorker_StartSubscribeError(t *testing.T) {
 	assert.Error(t, worker.Start())
 }
 
-func TestWriteBackWorker_RebaseOnVersionGap(t *testing.T) {
+func TestWriteBackWorker_RebaseOnAdjacentVersionGap(t *testing.T) {
 	logger := zap.NewNop()
 	provider := mock.NewMockDriverProvider(logger)
 	coll, err := provider.OpenDbDriver("wb-rebase")
@@ -145,7 +145,7 @@ func TestWriteBackWorker_RebaseOnVersionGap(t *testing.T) {
 		CollectionName: "wb-rebase",
 		Key:            k.String(),
 		Data:           json.RawMessage(`{"message":"rebased"}`),
-		Version:        5, // gap: earlier write-backs never arrived
+		Version:        2, // exactly one ahead: safe adjacent rebase
 	})))
 
 	assert.Eventually(t, func() bool {
@@ -157,6 +157,41 @@ func TestWriteBackWorker_RebaseOnVersionGap(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "rebased", got.Message)
 	assert.Equal(t, noptions.Version(2), ver)
+}
+
+func TestWriteBackWorker_RejectAmbiguousVersionGap(t *testing.T) {
+	logger := zap.NewNop()
+	provider := mock.NewMockDriverProvider(logger)
+	coll, err := provider.OpenDbDriver("wb-gap")
+	assert.NoError(t, err)
+
+	k, err := key.NewKeyFromParts("demo", "gap-1")
+	assert.NoError(t, err)
+
+	_, err = coll.Set(context.Background(), k, noptions.WithSource(&docPayload{Message: "fresh"}))
+	assert.NoError(t, err)
+
+	mq := &capturingMQ{}
+	worker := NewWriteBackWorker(mq, provider, logger)
+	assert.NoError(t, worker.Start())
+	defer worker.Stop()
+
+	assert.NoError(t, mq.Publish(WriteBackTopic, miface.WithJSON(&WriteBackPayload{
+		CollectionName: "wb-gap",
+		Key:            k.String(),
+		Data:           json.RawMessage(`{"message":"stale-inflight"}`),
+		Version:        9, // large gap: treat as ambiguous / possible recreate
+	})))
+
+	assert.Eventually(t, func() bool {
+		return worker.GetMetrics().FailedCount >= 1
+	}, time.Second, 10*time.Millisecond)
+
+	var got docPayload
+	_, err = coll.Get(context.Background(), k, noptions.WithDestination(&got))
+	assert.NoError(t, err)
+	assert.Equal(t, "fresh", got.Message)
+	assert.Equal(t, int64(0), worker.GetMetrics().ProcessedCount)
 }
 
 func TestWriteBackPayload_JSON(t *testing.T) {

--- a/orm/nosql/writeback_test.go
+++ b/orm/nosql/writeback_test.go
@@ -10,6 +10,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/gstones/moke-kit/mq/miface"
+	"github.com/gstones/moke-kit/orm/nosql/diface"
 	"github.com/gstones/moke-kit/orm/nosql/key"
 	"github.com/gstones/moke-kit/orm/nosql/mock"
 	"github.com/gstones/moke-kit/orm/nosql/noptions"
@@ -165,6 +166,66 @@ func TestWriteBackWorker_ApplyNewerTargetVersion(t *testing.T) {
 	assert.Equal(t, "latest", got.Message)
 	// Fast-forward must land exactly on the optimistic target version.
 	assert.Equal(t, noptions.Version(5), ver)
+}
+
+type jumpOnSecondGetCollection struct {
+	diface.ICollection
+	gets int
+}
+
+func (c *jumpOnSecondGetCollection) Get(
+	ctx context.Context,
+	k key.Key,
+	opts ...noptions.Option,
+) (noptions.Version, error) {
+	c.gets++
+	if c.gets == 2 {
+		// Between fast-forward iterations, an external writer advances the chain.
+		ver, err := c.ICollection.Get(ctx, k, opts...)
+		if err != nil {
+			return ver, err
+		}
+		_, err = c.ICollection.Set(
+			ctx,
+			k,
+			noptions.WithSource(&docPayload{Message: "external"}),
+			noptions.WithVersion(ver),
+		)
+		if err != nil {
+			return 0, err
+		}
+	}
+	return c.ICollection.Get(ctx, k, opts...)
+}
+
+func TestApplyWriteBackSnapshot_AbortsOnExternalVersionJump(t *testing.T) {
+	logger := zap.NewNop()
+	provider := mock.NewMockDriverProvider(logger)
+	coll, err := provider.OpenDbDriver("wb-jump")
+	assert.NoError(t, err)
+
+	k, err := key.NewKeyFromParts("demo", "jump-1")
+	assert.NoError(t, err)
+	_, err = coll.Set(context.Background(), k, noptions.WithSource(&docPayload{Message: "v1"}))
+	assert.NoError(t, err)
+
+	wrapped := &jumpOnSecondGetCollection{ICollection: coll}
+	err = applyWriteBackSnapshot(
+		context.Background(),
+		wrapped,
+		k,
+		map[string]any{"message": "wb"},
+		5,
+		nil,
+		0,
+	)
+	assert.ErrorIs(t, err, errWriteBackStale)
+
+	var got docPayload
+	ver, err := coll.Get(context.Background(), k, noptions.WithDestination(&got))
+	assert.NoError(t, err)
+	assert.Equal(t, "external", got.Message)
+	assert.Equal(t, noptions.Version(3), ver)
 }
 
 func TestWriteBackWorker_OutOfOrderTargetsKeepNewest(t *testing.T) {

--- a/orm/nosql/writeback_test.go
+++ b/orm/nosql/writeback_test.go
@@ -1,6 +1,7 @@
 package nosql
 
 import (
+	"context"
 	"encoding/json"
 	"testing"
 	"time"
@@ -8,6 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/zap"
 
+	"github.com/gstones/moke-kit/mq/miface"
 	"github.com/gstones/moke-kit/orm/nosql/mock"
 	"github.com/gstones/moke-kit/orm/nosql/noptions"
 )
@@ -77,6 +79,48 @@ func TestWriteBackWorker_GetMetrics(t *testing.T) {
 	metrics := worker.GetMetrics()
 	assert.GreaterOrEqual(t, metrics.ProcessedCount, int64(0))
 	assert.GreaterOrEqual(t, metrics.FailedCount, int64(0))
+}
+
+func TestWriteBackWorker_InvalidKeyNoPanic(t *testing.T) {
+	mq := &capturingMQ{}
+	provider := mock.NewMockDriverProvider(zap.NewNop())
+	worker := NewWriteBackWorker(mq, provider, zap.NewNop())
+	assert.NoError(t, worker.Start())
+	defer worker.Stop()
+
+	assert.NoError(t, mq.Publish(WriteBackTopic, miface.WithJSON(&WriteBackPayload{
+		CollectionName: "c",
+		Key:            "not-a-valid-key",
+		Data:           json.RawMessage(`{}`),
+		Version:        1,
+	})))
+
+	// Invalid keys are nacked as persistent failures and must not crash the worker.
+	assert.Equal(t, int64(0), worker.GetMetrics().ProcessedCount)
+}
+
+type failSubscribeMQ struct{}
+
+func (m *failSubscribeMQ) Publish(topic string, opts ...miface.PubOption) error {
+	return nil
+}
+
+func (m *failSubscribeMQ) Subscribe(
+	ctx context.Context,
+	topic string,
+	handler miface.SubResponseHandler,
+	opts ...miface.SubOption,
+) (miface.Subscription, error) {
+	return nil, assert.AnError
+}
+
+func TestWriteBackWorker_StartSubscribeError(t *testing.T) {
+	worker := NewWriteBackWorker(
+		&failSubscribeMQ{},
+		mock.NewMockDriverProvider(zap.NewNop()),
+		zap.NewNop(),
+	)
+	assert.Error(t, worker.Start())
 }
 
 func TestWriteBackPayload_JSON(t *testing.T) {

--- a/orm/nosql/writeback_test.go
+++ b/orm/nosql/writeback_test.go
@@ -166,6 +166,50 @@ func TestWriteBackWorker_ApplyNewerTargetVersion(t *testing.T) {
 	assert.Equal(t, noptions.Version(2), ver)
 }
 
+func TestWriteBackWorker_RejectEpochMismatch(t *testing.T) {
+	logger := zap.NewNop()
+	provider := mock.NewMockDriverProvider(logger)
+	coll, err := provider.OpenDbDriver("wb-epoch")
+	assert.NoError(t, err)
+
+	k, err := key.NewKeyFromParts("demo", "epoch-1")
+	assert.NoError(t, err)
+
+	// Recreated document at version 1 (old delayed write-back may carry a higher target).
+	_, err = coll.Set(context.Background(), k, noptions.WithSource(&docPayload{Message: "recreated"}))
+	assert.NoError(t, err)
+
+	cache := newMemoryHashCache()
+	assert.NoError(t, cache.SetCache(context.Background(), k, map[string]any{
+		cacheFieldVersion: noptions.Version(1),
+		cacheFieldEpoch:   int64(2),
+		cacheFieldData:    `{"message":"recreated"}`,
+	}, time.Minute))
+
+	mq := &capturingMQ{}
+	worker := NewWriteBackWorker(mq, provider, logger).WithCache(cache)
+	assert.NoError(t, worker.Start())
+	defer worker.Stop()
+
+	assert.NoError(t, mq.Publish(WriteBackTopic, miface.WithJSON(&WriteBackPayload{
+		CollectionName: "wb-epoch",
+		Key:            k.String(),
+		Data:           json.RawMessage(`{"message":"stale-generation"}`),
+		Version:        9,
+		Epoch:          1,
+	})))
+
+	assert.Eventually(t, func() bool {
+		return worker.GetMetrics().FailedCount >= 1
+	}, time.Second, 10*time.Millisecond)
+
+	var got docPayload
+	_, err = coll.Get(context.Background(), k, noptions.WithDestination(&got))
+	assert.NoError(t, err)
+	assert.Equal(t, "recreated", got.Message)
+	assert.Equal(t, int64(0), worker.GetMetrics().ProcessedCount)
+}
+
 func TestWriteBackWorker_RejectStaleTargetVersion(t *testing.T) {
 	logger := zap.NewNop()
 	provider := mock.NewMockDriverProvider(logger)
@@ -214,6 +258,7 @@ func TestWriteBackPayload_JSON(t *testing.T) {
 		Key:            "test_key",
 		Data:           json.RawMessage(`{"name":"John","age":30}`),
 		Version:        noptions.Version(1),
+		Epoch:          3,
 	}
 
 	data, err := json.Marshal(payload)
@@ -226,4 +271,5 @@ func TestWriteBackPayload_JSON(t *testing.T) {
 	assert.Equal(t, payload.CollectionName, decoded.CollectionName)
 	assert.Equal(t, payload.Key, decoded.Key)
 	assert.Equal(t, payload.Version, decoded.Version)
+	assert.Equal(t, payload.Epoch, decoded.Epoch)
 }

--- a/orm/nosql/writeback_test.go
+++ b/orm/nosql/writeback_test.go
@@ -163,7 +163,49 @@ func TestWriteBackWorker_ApplyNewerTargetVersion(t *testing.T) {
 	ver, err := coll.Get(context.Background(), k, noptions.WithDestination(&got))
 	assert.NoError(t, err)
 	assert.Equal(t, "latest", got.Message)
-	assert.Equal(t, noptions.Version(2), ver)
+	// Fast-forward must land exactly on the optimistic target version.
+	assert.Equal(t, noptions.Version(5), ver)
+}
+
+func TestWriteBackWorker_OutOfOrderTargetsKeepNewest(t *testing.T) {
+	logger := zap.NewNop()
+	provider := mock.NewMockDriverProvider(logger)
+	coll, err := provider.OpenDbDriver("wb-ooo")
+	assert.NoError(t, err)
+
+	k, err := key.NewKeyFromParts("demo", "ooo-1")
+	assert.NoError(t, err)
+
+	_, err = coll.Set(context.Background(), k, noptions.WithSource(&docPayload{Message: "v1"}))
+	assert.NoError(t, err)
+
+	mq := &capturingMQ{}
+	worker := NewWriteBackWorker(mq, provider, logger)
+	assert.NoError(t, worker.Start())
+	defer worker.Stop()
+
+	assert.NoError(t, mq.Publish(WriteBackTopic, miface.WithJSON(&WriteBackPayload{
+		CollectionName: "wb-ooo",
+		Key:            k.String(),
+		Data:           json.RawMessage(`{"message":"latest"}`),
+		Version:        5,
+	})))
+	assert.NoError(t, mq.Publish(WriteBackTopic, miface.WithJSON(&WriteBackPayload{
+		CollectionName: "wb-ooo",
+		Key:            k.String(),
+		Data:           json.RawMessage(`{"message":"older"}`),
+		Version:        4,
+	})))
+
+	assert.Eventually(t, func() bool {
+		return worker.GetMetrics().ProcessedCount >= 1 && worker.GetMetrics().FailedCount >= 1
+	}, time.Second, 10*time.Millisecond)
+
+	var got docPayload
+	ver, err := coll.Get(context.Background(), k, noptions.WithDestination(&got))
+	assert.NoError(t, err)
+	assert.Equal(t, "latest", got.Message)
+	assert.Equal(t, noptions.Version(5), ver)
 }
 
 func TestWriteBackWorker_RejectEpochMismatch(t *testing.T) {

--- a/orm/nosql/writeback_test.go
+++ b/orm/nosql/writeback_test.go
@@ -1,0 +1,100 @@
+package nosql
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
+
+	"github.com/gstones/moke-kit/orm/nosql/mock"
+	"github.com/gstones/moke-kit/orm/nosql/noptions"
+)
+
+func TestWriteBackOptions_Validate(t *testing.T) {
+	tests := []struct {
+		name    string
+		opts    WriteBackOptions
+		wantErr bool
+	}{
+		{
+			name: "valid disabled options",
+			opts: WriteBackOptions{
+				Enabled: false,
+				Delay:   time.Second,
+				MQ:      nil,
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid enabled options",
+			opts: WriteBackOptions{
+				Enabled: true,
+				Delay:   time.Second,
+				MQ:      &capturingMQ{},
+			},
+			wantErr: false,
+		},
+		{
+			name: "invalid: enabled but no MQ",
+			opts: WriteBackOptions{
+				Enabled: true,
+				Delay:   time.Second,
+				MQ:      nil,
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid: negative delay",
+			opts: WriteBackOptions{
+				Enabled: false,
+				Delay:   -time.Second,
+				MQ:      nil,
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.opts.Validate()
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestWriteBackWorker_GetMetrics(t *testing.T) {
+	worker := NewWriteBackWorker(
+		&capturingMQ{},
+		mock.NewMockDriverProvider(zap.NewNop()),
+		zap.NewNop(),
+	)
+	metrics := worker.GetMetrics()
+	assert.GreaterOrEqual(t, metrics.ProcessedCount, int64(0))
+	assert.GreaterOrEqual(t, metrics.FailedCount, int64(0))
+}
+
+func TestWriteBackPayload_JSON(t *testing.T) {
+	payload := WriteBackPayload{
+		CollectionName: "test_collection",
+		Key:            "test_key",
+		Data:           json.RawMessage(`{"name":"John","age":30}`),
+		Version:        noptions.Version(1),
+	}
+
+	data, err := json.Marshal(payload)
+	assert.NoError(t, err)
+	assert.NotEmpty(t, data)
+
+	var decoded WriteBackPayload
+	err = json.Unmarshal(data, &decoded)
+	assert.NoError(t, err)
+	assert.Equal(t, payload.CollectionName, decoded.CollectionName)
+	assert.Equal(t, payload.Key, decoded.Key)
+	assert.Equal(t, payload.Version, decoded.Version)
+}

--- a/test/orm/nosql_test.go
+++ b/test/orm/nosql_test.go
@@ -274,15 +274,17 @@ func TestDocumentCache(t *testing.T) {
 		k, err := key.NewKeyFromParts("test", "cache", "item1")
 		helper.RequireNoError(err)
 
-		data := &TestData{Message: "cached data", Count: 100}
+		data := map[string]any{
+			"Message": "cached data",
+			"Count":   100,
+		}
 
-		// Test cache set (default implementation does nothing)
-		cache.SetCache(helper.Context(), k, data, 5*time.Minute)
+		// Test cache set (default implementation is a no-op)
+		helper.RequireNoError(cache.SetCache(helper.Context(), k, data, 5*time.Minute))
 
-		// Test cache get (default implementation returns false)
-		var retrieved TestData
-		found := cache.GetCache(helper.Context(), k, &retrieved)
-		helper.AssertFalse(found, "Default cache should not find items")
+		// Test cache get (default implementation returns nil)
+		found := cache.GetCache(helper.Context(), k)
+		helper.AssertTrue(len(found) == 0, "Default cache should not find items")
 
 		// Test cache delete (default implementation does nothing)
 		cache.DeleteCache(helper.Context(), k)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Completes [#215](https://github.com/GStones/moke-kit/pull/215) / [#214](https://github.com/GStones/moke-kit/issues/214) by rebasing the document-cache refactor onto current `main` and fixing the blockers that kept PR #215 unmergeable.

The same commit is also force-pushed to `214-refactor-refactor-document-update` so [#215](https://github.com/GStones/moke-kit/pull/215) stays current. Prefer merging one of these PRs (not both).

### What changed
- **Redis HASH cache**: `ICache` / `RedisCache` now use HASH field maps instead of a single JSON string blob.
- **Versioned envelope**: Document cache entries store `__version` + `__data` so CAS version survives cache hits and protobuf/`**T` payloads stay compatible with platform/game DAOs.
- **Async write-back**: `SaveAsync` / `UpdateAsync` + `WriteBackWorker` / `WriteBackManager` publish delayed MQ messages and persist to Mongo with versioned CAS.
- **Tests**: Removed hanging `fxmain.Main` integration tests; added unit coverage for HASH read-through and write-back. `test/orm` updated for the new `ICache` API.
- **Mock provider**: `OpenDbDriver` reuses collections by name so write-back workers observe the same in-memory store.

### Intentionally kept from main
- Mongo create/CAS/`FindOneAndUpdate` contracts
- MQ cancel-subscription lifecycle and existing `SubResponseHandler` signature (no breaking MQ API change)
- Stabilized `DocumentBase` concurrent CAS unit tests

### Follow-ups (out of scope here)
- Redis Lua CAS atomicity from issue #214 / draft [#220](https://github.com/GStones/moke-kit/pull/220)
- Platform/game COMPATIBILITY bump after merge (breaking `ICache` shape)

### Test plan
- [x] `go test ./...`
- [x] `staticcheck ./orm/nosql/...`
- [ ] CI green on this PR

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-43a0affb-9440-4553-b494-83f21af8ad9c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-43a0affb-9440-4553-b494-83f21af8ad9c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

